### PR TITLE
JOING-18 feat: 카카오 소셜 로그인 및 회원가입 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	//swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 }

--- a/src/main/java/com/ktb/joing/common/config/RedisConfig.java
+++ b/src/main/java/com/ktb/joing/common/config/RedisConfig.java
@@ -1,0 +1,19 @@
+package com.ktb.joing.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+}

--- a/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.ktb.joing.common.config;
 
+import com.ktb.joing.domain.auth.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -10,7 +12,10 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -28,7 +33,9 @@ public class SecurityConfig {
 
         //oauth2 로그인 설정
         http
-                .oauth2Login(Customizer.withDefaults());
+                .oauth2Login((oauth) -> oauth
+                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService)));
 
         //경로별 인가 작업
         http

--- a/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
@@ -1,0 +1,46 @@
+package com.ktb.joing.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        //csrf 비횔성화
+        http
+                .csrf((auth) -> auth.disable());
+
+        //From 로그인 방식 비활성화
+        http
+                .formLogin((auth) -> auth.disable());
+
+        //HTTP Basic 인증 방식 비활성화
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        //oauth2 로그인 설정
+        http
+                .oauth2Login(Customizer.withDefaults());
+
+        //경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/").permitAll()
+                        .anyRequest().authenticated());
+
+        //세션 설정 : STATELESS
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/auth/cookie/CookieUtils.java
+++ b/src/main/java/com/ktb/joing/domain/auth/cookie/CookieUtils.java
@@ -1,0 +1,58 @@
+package com.ktb.joing.domain.auth.cookie;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class CookieUtils {
+
+    //특정 이름의 쿠키를 찾아 Optional<Cookie>로 반환하는 메서드
+    public Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (isNotEmpty(cookies)) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    public Cookie createCookie(String name, String value) {
+
+        Cookie cookie = new Cookie(name, value);
+        cookie.setMaxAge(24*60*60);
+//        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+    // 특정 이름의 쿠키를 삭제하는 메서드
+    public void deleteCookie(HttpServletRequest request, HttpServletResponse response,
+                                    String name) {
+        Cookie[] cookies = request.getCookies();
+        if (isNotEmpty(cookies)) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+
+    // 쿠키 배열이 null이 아니고 길이가 0보다 큰지 확인하는 유틸리티 메서드
+    private static boolean isNotEmpty(Cookie[] cookies) {
+        return cookies != null && cookies.length > 0;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/auth/dto/CustomOAuth2User.java
+++ b/src/main/java/com/ktb/joing/domain/auth/dto/CustomOAuth2User.java
@@ -1,0 +1,46 @@
+package com.ktb.joing.domain.auth.dto;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+public class CustomOAuth2User implements OAuth2User {
+
+    private final UserDto userDto;
+
+    public CustomOAuth2User(UserDto userDto) {
+        this.userDto = userDto;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+
+            @Override
+            public String getAuthority() {
+                return userDto.getRole().name();
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+        return userDto.getName();
+    }
+
+    public String getUsername() {
+        return userDto.getUsername();
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/auth/dto/KakaoResponse.java
+++ b/src/main/java/com/ktb/joing/domain/auth/dto/KakaoResponse.java
@@ -1,5 +1,7 @@
 package com.ktb.joing.domain.auth.dto;
 
+import com.ktb.joing.domain.user.entity.SocialProvider;
+
 import java.util.Map;
 
 public class KakaoResponse implements OAuth2Response {
@@ -10,8 +12,8 @@ public class KakaoResponse implements OAuth2Response {
     }
 
     @Override
-    public String getProvider() {
-        return "kakao";
+    public SocialProvider getProvider() {
+        return SocialProvider.KAKAO;
     }
 
     @Override

--- a/src/main/java/com/ktb/joing/domain/auth/dto/KakaoResponse.java
+++ b/src/main/java/com/ktb/joing/domain/auth/dto/KakaoResponse.java
@@ -1,0 +1,46 @@
+package com.ktb.joing.domain.auth.dto;
+
+import java.util.Map;
+
+public class KakaoResponse implements OAuth2Response {
+    private final Map<String, Object> attribute;
+
+    public KakaoResponse(Map<String, Object> attribute) {
+        this.attribute = attribute;
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        // "kakao_account" 필드에 포함된 "email" 값을 가져온다.
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attribute.get("kakao_account");
+        if (kakaoAccount != null) {
+            return kakaoAccount.get("email").toString();
+        }
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        // "kakao_account" 필드에 포함된 "name" 값을 가져온다.
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attribute.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        return profile.get("nickname").toString();
+    }
+
+    @Override
+    public String getProfileImage() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attribute.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        return profile.get("profile_image_url").toString();
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/auth/dto/OAuth2Response.java
+++ b/src/main/java/com/ktb/joing/domain/auth/dto/OAuth2Response.java
@@ -1,8 +1,10 @@
 package com.ktb.joing.domain.auth.dto;
 
+import com.ktb.joing.domain.user.entity.SocialProvider;
+
 public interface OAuth2Response {
     //제공자 (Ex. naver, google, ...)
-    String getProvider();
+    SocialProvider getProvider();
     //제공자에서 발급해주는 아이디(번호)
     String getProviderId();
     //이메일

--- a/src/main/java/com/ktb/joing/domain/auth/dto/OAuth2Response.java
+++ b/src/main/java/com/ktb/joing/domain/auth/dto/OAuth2Response.java
@@ -1,0 +1,14 @@
+package com.ktb.joing.domain.auth.dto;
+
+public interface OAuth2Response {
+    //제공자 (Ex. naver, google, ...)
+    String getProvider();
+    //제공자에서 발급해주는 아이디(번호)
+    String getProviderId();
+    //이메일
+    String getEmail();
+    //사용자 실명 (설정한 이름)
+    String getName();
+    //사용자 프로필 이미지
+    String getProfileImage();
+}

--- a/src/main/java/com/ktb/joing/domain/auth/dto/UserDto.java
+++ b/src/main/java/com/ktb/joing/domain/auth/dto/UserDto.java
@@ -1,0 +1,13 @@
+package com.ktb.joing.domain.auth.dto;
+
+import com.ktb.joing.domain.user.entity.Role;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserDto {
+    private String username;
+    private String name;
+    private Role role;
+}

--- a/src/main/java/com/ktb/joing/domain/auth/dto/UserDto.java
+++ b/src/main/java/com/ktb/joing/domain/auth/dto/UserDto.java
@@ -1,6 +1,7 @@
 package com.ktb.joing.domain.auth.dto;
 
 import com.ktb.joing.domain.user.entity.Role;
+import com.ktb.joing.domain.user.entity.SocialProvider;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,5 +10,8 @@ import lombok.Setter;
 public class UserDto {
     private String username;
     private String name;
+    private SocialProvider provider;
+    private String providerId;
+    private String profileImage;
     private Role role;
 }

--- a/src/main/java/com/ktb/joing/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/ktb/joing/domain/auth/exception/AuthErrorCode.java
@@ -12,7 +12,8 @@ public enum AuthErrorCode implements ErrorCode {
     // Auth Error
     OAUTH2_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "로그인 실패"),
     INVALID_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
-    EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
+    TEMP_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "임시 사용자 정보를 찾을 수 없습니다"),
     HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다"),
     AUTHENTICATION_ENTRY_POINT(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
     REDIRECT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다");

--- a/src/main/java/com/ktb/joing/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/ktb/joing/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,22 @@
+package com.ktb.joing.domain.auth.exception;
+
+import com.ktb.joing.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+
+public enum AuthErrorCode implements ErrorCode {
+    // Auth Error
+    OAUTH2_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "로그인 실패"),
+    INVALID_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+    EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다"),
+    HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다"),
+    AUTHENTICATION_ENTRY_POINT(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
+    REDIRECT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/ktb/joing/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/ktb/joing/domain/auth/exception/AuthException.java
@@ -4,10 +4,10 @@ import com.ktb.joing.common.exception.BusinessException;
 import lombok.Getter;
 
 @Getter
-public class InvalidJwtException extends BusinessException {
+public class AuthException extends BusinessException {
     private final AuthErrorCode authErrorCode;
 
-    public InvalidJwtException(AuthErrorCode authErrorCode){
+    public AuthException(AuthErrorCode authErrorCode){
         super(authErrorCode);
         this.authErrorCode = authErrorCode;
     }

--- a/src/main/java/com/ktb/joing/domain/auth/exception/InvalidJwtException.java
+++ b/src/main/java/com/ktb/joing/domain/auth/exception/InvalidJwtException.java
@@ -1,0 +1,14 @@
+package com.ktb.joing.domain.auth.exception;
+
+import com.ktb.joing.common.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class InvalidJwtException extends BusinessException {
+    private final AuthErrorCode authErrorCode;
+
+    public InvalidJwtException(AuthErrorCode authErrorCode){
+        super(authErrorCode);
+        this.authErrorCode = authErrorCode;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/auth/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/ktb/joing/domain/auth/handler/CustomSuccessHandler.java
@@ -1,0 +1,60 @@
+package com.ktb.joing.domain.auth.handler;
+
+import com.ktb.joing.domain.auth.cookie.CookieUtils;
+import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
+import com.ktb.joing.domain.auth.jwt.JwtUtil;
+
+import com.ktb.joing.domain.auth.jwt.TokenService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    @Value("${app.frontend.url}")
+    private String frontUrl;
+
+    private final JwtUtil jwtUtil;
+    private final CookieUtils cooKieUtils;
+    private final TokenService tokenService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        //유저 정보
+        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+
+        String username = customUserDetails.getUsername();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+        // 토큰 생성
+        String access = jwtUtil.createAccessToken("access", username, role);
+        String refresh = jwtUtil.createRefreshToken("refresh", username, role);
+
+        //Refresh 토큰 저장
+        tokenService.saveRefreshToken(username, refresh);
+
+        //응답 설정
+        response.setHeader("access", access); // 응답헤더에 엑세스 토큰
+        response.addCookie(cooKieUtils.createCookie("refresh", refresh)); // 응답쿠키에 리프레시 토큰
+        response.sendRedirect(frontUrl);
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/JwtFilter.java
@@ -2,7 +2,7 @@ package com.ktb.joing.domain.auth.jwt;
 
 import com.ktb.joing.domain.auth.cookie.CookieUtils;
 import com.ktb.joing.domain.auth.exception.AuthErrorCode;
-import com.ktb.joing.domain.auth.exception.InvalidJwtException;
+import com.ktb.joing.domain.auth.exception.AuthException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -53,7 +53,7 @@ public class JwtFilter extends OncePerRequestFilter {
             // 2. Access 토큰 카테고리 검증
             if (accessToken != null && !jwtUtil.getCategoryFromToken(accessToken).equals("access")) {
                 log.error("Invalid access token category");
-                throw new InvalidJwtException(AuthErrorCode.INVALID_JWT);
+                throw new AuthException(AuthErrorCode.INVALID_JWT);
             }
 
             // 3. Access 토큰이 유효한 경우

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/JwtFilter.java
@@ -1,7 +1,6 @@
 package com.ktb.joing.domain.auth.jwt;
 
 import com.ktb.joing.domain.auth.cookie.CookieUtils;
-import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
 import com.ktb.joing.domain.auth.exception.AuthErrorCode;
 import com.ktb.joing.domain.auth.exception.InvalidJwtException;
 import jakarta.servlet.FilterChain;
@@ -15,6 +14,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -104,20 +104,25 @@ public class JwtFilter extends OncePerRequestFilter {
                 requestUri.matches("^\\/oauth2(?:\\/.*)?$");
     }
 
+
     private void setAuthentication(String username, String role) {
-        CustomOAuth2User customOAuth2User = getUserDetails(username, role);
-        Authentication authentication = getAuthentication(customOAuth2User);
+        UserDetails userDetails = createUserDetails(username, role);
+        Authentication authentication = getAuthentication(userDetails);
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     //스프링 시큐리티 인증 토큰 생성
-    private Authentication getAuthentication(CustomOAuth2User userDetails){
-        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    private Authentication getAuthentication(UserDetails userDetails){
+        return new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        );
     }
 
     // UserDetails 객체 생성
-    private CustomOAuth2User getUserDetails(String username, String role){
-        return (CustomOAuth2User) User.builder()
+    private UserDetails createUserDetails(String username, String role) {
+        return User.builder()
                 .username(username)
                 .password("")
                 .authorities(role)

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/JwtFilter.java
@@ -1,0 +1,126 @@
+package com.ktb.joing.domain.auth.jwt;
+
+import com.ktb.joing.domain.auth.cookie.CookieUtils;
+import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
+import com.ktb.joing.domain.auth.exception.AuthErrorCode;
+import com.ktb.joing.domain.auth.exception.InvalidJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final CookieUtils cookieUtils;
+    private final TokenService tokenService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        // jwt 기간 만료시, 무한 재로그인 방지 로직
+        if (isOAuth2RelatedPath(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = request.getHeader("access");
+        Optional<Cookie> refreshTokenCookie = cookieUtils.getCookie(request, "refresh");
+        String refreshToken = refreshTokenCookie.map(Cookie::getValue).orElse(null);
+
+        try {
+            // 1. 토큰이 모두 없는 경우
+            if (accessToken == null && refreshToken == null) {
+                log.info("No tokens present");
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // 2. Access 토큰 카테고리 검증
+            if (accessToken != null && !jwtUtil.getCategoryFromToken(accessToken).equals("access")) {
+                log.error("Invalid access token category");
+                throw new InvalidJwtException(AuthErrorCode.INVALID_JWT);
+            }
+
+            // 3. Access 토큰이 유효한 경우
+            if (accessToken != null && jwtUtil.isTokenValid(accessToken)) {
+                log.info("Valid access token");
+                setAuthentication(
+                        jwtUtil.getUsernameFromToken(accessToken),
+                        jwtUtil.getRoleFromToken(accessToken)
+                );
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // 4. Access 토큰이 만료되고 Refresh 토큰이 유효한 경우
+            if (refreshToken != null && jwtUtil.isTokenValid(refreshToken)) {
+                log.info("Access token expired, but refresh token valid");
+                String newAccessToken = tokenService.reissueAccessToken(response, refreshToken);
+                setAuthentication(
+                        jwtUtil.getUsernameFromToken(newAccessToken),
+                        jwtUtil.getRoleFromToken(newAccessToken)
+                );
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // 5. Refresh 토큰도 만료된 경우
+            if (refreshToken != null) {
+                log.info("Both tokens expired");
+                cookieUtils.deleteCookie(request, response, "refresh");
+                tokenService.deleteRefreshToken(refreshToken);
+            }
+
+            // 6. 그 외의 경우 (유효하지 않은 토큰)
+            log.info("Invalid tokens");
+            filterChain.doFilter(request, response);
+
+        } catch (Exception e) {
+            log.error("JWT Filter Error", e);
+            cookieUtils.deleteCookie(request, response, "refresh");
+            throw e;
+        }
+    }
+
+    //jwt 기간 만료시, 무한 재로그인 방지 로직
+    private boolean isOAuth2RelatedPath(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        return requestUri.matches("^\\/login(?:\\/.*)?$") ||
+                requestUri.matches("^\\/oauth2(?:\\/.*)?$");
+    }
+
+    private void setAuthentication(String username, String role) {
+        CustomOAuth2User customOAuth2User = getUserDetails(username, role);
+        Authentication authentication = getAuthentication(customOAuth2User);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    //스프링 시큐리티 인증 토큰 생성
+    private Authentication getAuthentication(CustomOAuth2User userDetails){
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    // UserDetails 객체 생성
+    private CustomOAuth2User getUserDetails(String username, String role){
+        return (CustomOAuth2User) User.builder()
+                .username(username)
+                .password("")
+                .authorities(role)
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/JwtUtil.java
@@ -1,0 +1,91 @@
+package com.ktb.joing.domain.auth.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+@Slf4j
+public class JwtUtil {
+
+    private final String SECRET_KEY;
+    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 6; //6시간
+    private static final long REFRESH_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 24 * 14; //2주
+
+    public JwtUtil(@Value("${spring.jwt.secret}") String secretKey) {
+        this.SECRET_KEY = secretKey;
+    }
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // 토큰에 대한 검증 메소드
+    public Boolean isTokenValid(String token) {
+        try {
+            getClaimsFromToken(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT token 입니다.");
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("유효하지 않는 JWT 서명 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    public String getUsernameFromToken(String token) {
+
+        return getClaimsFromToken(token).get("username", String.class);
+    }
+
+    public String getRoleFromToken(String token) {
+
+        return getClaimsFromToken(token).get("role", String.class);
+    }
+
+    private Claims getClaimsFromToken(String token) {
+        return Jwts.parser().verifyWith(getSigningKey()).build().parseSignedClaims(token).getPayload();
+    }
+
+    public String getCategoryFromToken(String token) {
+        return Jwts.parser().verifyWith(getSigningKey()).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+
+    public String createAccessToken(String category, String username, String role) {
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION_TIME);
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expireDate)
+                .signWith(getSigningKey()).compact();
+    }
+
+    public String createRefreshToken(String category, String username, String role) {
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME);
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expireDate)
+                .signWith(getSigningKey()).compact();
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/JwtUtil.java
@@ -21,6 +21,8 @@ public class JwtUtil {
     private final String SECRET_KEY;
     private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 6; //6시간
     private static final long REFRESH_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 24 * 14; //2주
+    private static final long TEMP_ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60 * 30; // 30분
+    private static final long TEMP_REFRESH_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 24; // 24시간
 
     public JwtUtil(@Value("${spring.jwt.secret}") String secretKey) {
         this.SECRET_KEY = secretKey;
@@ -80,6 +82,31 @@ public class JwtUtil {
     public String createRefreshToken(String category, String username, String role) {
         Date now = new Date();
         Date expireDate = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME);
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expireDate)
+                .signWith(getSigningKey()).compact();
+    }
+
+    public String createTempAccessToken(String category, String username, String role) {
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + TEMP_ACCESS_TOKEN_EXPIRATION_TIME);
+
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expireDate)
+                .signWith(getSigningKey()).compact();
+    }
+
+    public String createTempRefreshToken(String category, String username, String role) {
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + TEMP_REFRESH_TOKEN_EXPIRATION_TIME);
         return Jwts.builder()
                 .claim("category", category)
                 .claim("username", username)

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/RefreshToken.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/RefreshToken.java
@@ -1,13 +1,13 @@
 package com.ktb.joing.domain.auth.jwt;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
 
-@Entity
 @Getter
 @NoArgsConstructor
+@RedisHash(value = "refreshToken", timeToLive = 1209600)
 public class RefreshToken {
     @Id
     private String refreshToken;

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/RefreshToken.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/RefreshToken.java
@@ -1,0 +1,20 @@
+package com.ktb.joing.domain.auth.jwt;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RefreshToken {
+    @Id
+    private String refreshToken;
+    private String username;
+
+    public RefreshToken(String username, String refreshToken) {
+        this.username = username;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/RefreshTokenRepository.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/RefreshTokenRepository.java
@@ -1,6 +1,8 @@
 package com.ktb.joing.domain.auth.jwt;
 
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 }

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/RefreshTokenRepository.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/RefreshTokenRepository.java
@@ -1,0 +1,6 @@
+package com.ktb.joing.domain.auth.jwt;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/TokenService.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/TokenService.java
@@ -1,0 +1,50 @@
+package com.ktb.joing.domain.auth.jwt;
+
+import com.ktb.joing.domain.auth.exception.AuthErrorCode;
+import com.ktb.joing.domain.auth.exception.InvalidJwtException;
+import com.ktb.joing.domain.user.entity.User;
+import com.ktb.joing.domain.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    // 리프레시 토큰을 이용해 새로운 액세스 토큰을 발급하고 응답 헤더에 설정
+    public String reissueAccessToken(HttpServletResponse response, String refreshToken) {
+        String renewAccessToken = createAccessToken(refreshToken);
+        response.setHeader("access", renewAccessToken);
+        return renewAccessToken;
+    }
+
+    // 리프레시 토큰으로부터 새로운 액세스 토큰 생성
+    public String createAccessToken(final String refreshToken) {
+        RefreshToken findRefreshToken = refreshTokenRepository.findById(refreshToken)
+                .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT));
+
+        User user = userRepository.findByUsername(findRefreshToken.getUsername())
+                .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT));
+
+
+        return jwtUtil.createAccessToken(
+                "access",
+                user.getUsername(),
+                user.getRole().name()
+        );
+    }
+
+    // 리프레시 토큰 저장
+    public void saveRefreshToken(String username, String refreshToken) {
+        refreshTokenRepository.save(new RefreshToken(username, refreshToken));
+    }
+
+    //리프레시 토큰 삭제
+    public void deleteRefreshToken(String refreshToken) {
+        refreshTokenRepository.deleteById(refreshToken);
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/TokenService.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/TokenService.java
@@ -2,6 +2,8 @@ package com.ktb.joing.domain.auth.jwt;
 
 import com.ktb.joing.domain.auth.exception.AuthErrorCode;
 import com.ktb.joing.domain.auth.exception.InvalidJwtException;
+import com.ktb.joing.domain.auth.redis.TempUser;
+import com.ktb.joing.domain.auth.redis.TempUserRepository;
 import com.ktb.joing.domain.user.entity.User;
 import com.ktb.joing.domain.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
@@ -13,22 +15,32 @@ import org.springframework.stereotype.Service;
 public class TokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
+    private final TempUserRepository tempUserRepository;
     private final JwtUtil jwtUtil;
 
     // 리프레시 토큰을 이용해 새로운 액세스 토큰을 발급하고 응답 헤더에 설정
     public String reissueAccessToken(HttpServletResponse response, String refreshToken) {
-        String renewAccessToken = createAccessToken(refreshToken);
+        String username = getUsernameFromRefreshToken(refreshToken);
+        String renewAccessToken = null;
+
+        // 임시 회원인지 확인하고 해당하는 토큰 발급
+        if (tempUserRepository.findById(username).isPresent()) {
+            renewAccessToken = createTempAccessToken(refreshToken);
+        } else {
+            renewAccessToken = createAccessToken(refreshToken);
+        }
+
         response.setHeader("access", renewAccessToken);
         return renewAccessToken;
     }
 
     // 리프레시 토큰으로부터 새로운 액세스 토큰 생성
-    public String createAccessToken(final String refreshToken) {
+    public String createAccessToken(String refreshToken) {
         RefreshToken findRefreshToken = refreshTokenRepository.findById(refreshToken)
                 .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT));
 
         User user = userRepository.findByUsername(findRefreshToken.getUsername())
-                .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT));
+                .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT)); // 에러 바꾸기
 
 
         return jwtUtil.createAccessToken(
@@ -36,6 +48,28 @@ public class TokenService {
                 user.getUsername(),
                 user.getRole().name()
         );
+    }
+
+    // 임시 회원용 액세스 토큰 생성
+    private String createTempAccessToken(String refreshToken) {
+        RefreshToken findRefreshToken = refreshTokenRepository.findById(refreshToken)
+                .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT));
+
+        TempUser tempUser =  tempUserRepository.findById(findRefreshToken.getUsername())
+                .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT));
+
+        return jwtUtil.createTempAccessToken(
+                "access",
+                tempUser.getId(),
+                tempUser.getRole().name()
+        );
+    }
+
+    // 리프레시 토큰에서 username 추출
+    private String getUsernameFromRefreshToken(String refreshToken) {
+        RefreshToken findRefreshToken = refreshTokenRepository.findById(refreshToken)
+                .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT));
+        return findRefreshToken.getUsername();
     }
 
     // 리프레시 토큰 저장
@@ -47,4 +81,6 @@ public class TokenService {
     public void deleteRefreshToken(String refreshToken) {
         refreshTokenRepository.deleteById(refreshToken);
     }
+
+
 }

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/TokenService.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/TokenService.java
@@ -1,7 +1,7 @@
 package com.ktb.joing.domain.auth.jwt;
 
 import com.ktb.joing.domain.auth.exception.AuthErrorCode;
-import com.ktb.joing.domain.auth.exception.InvalidJwtException;
+import com.ktb.joing.domain.auth.exception.AuthException;
 import com.ktb.joing.domain.auth.redis.TempUser;
 import com.ktb.joing.domain.auth.redis.TempUserRepository;
 import com.ktb.joing.domain.user.entity.User;
@@ -37,10 +37,10 @@ public class TokenService {
     // 리프레시 토큰으로부터 새로운 액세스 토큰 생성
     public String createAccessToken(String refreshToken) {
         RefreshToken findRefreshToken = refreshTokenRepository.findById(refreshToken)
-                .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT));
+                .orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_JWT));
 
         User user = userRepository.findByUsername(findRefreshToken.getUsername())
-                .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT)); // 에러 바꾸기
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
 
         return jwtUtil.createAccessToken(
@@ -53,10 +53,10 @@ public class TokenService {
     // 임시 회원용 액세스 토큰 생성
     private String createTempAccessToken(String refreshToken) {
         RefreshToken findRefreshToken = refreshTokenRepository.findById(refreshToken)
-                .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT));
+                .orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_JWT));
 
         TempUser tempUser =  tempUserRepository.findById(findRefreshToken.getUsername())
-                .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT));
+                .orElseThrow(() -> new AuthException(AuthErrorCode.TEMP_USER_NOT_FOUND));
 
         return jwtUtil.createTempAccessToken(
                 "access",
@@ -68,7 +68,7 @@ public class TokenService {
     // 리프레시 토큰에서 username 추출
     private String getUsernameFromRefreshToken(String refreshToken) {
         RefreshToken findRefreshToken = refreshTokenRepository.findById(refreshToken)
-                .orElseThrow(() -> new InvalidJwtException(AuthErrorCode.INVALID_JWT));
+                .orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_JWT));
         return findRefreshToken.getUsername();
     }
 

--- a/src/main/java/com/ktb/joing/domain/auth/redis/TempUser.java
+++ b/src/main/java/com/ktb/joing/domain/auth/redis/TempUser.java
@@ -1,5 +1,6 @@
 package com.ktb.joing.domain.auth.redis;
 
+import com.ktb.joing.domain.user.entity.Role;
 import com.ktb.joing.domain.user.entity.SocialProvider;
 import jakarta.persistence.Id;
 import lombok.Builder;
@@ -14,12 +15,14 @@ public class TempUser {
     private final String profileImage;
     private final String socialId;
     private final SocialProvider socialProvider;
+    private final Role role;
 
     @Builder
-    public TempUser(String id, String profileImage, String socialId, SocialProvider socialProvider) {
+    public TempUser(String id, String profileImage, String socialId, SocialProvider socialProvider, Role role) {
         this.id = id;
         this.profileImage = profileImage;
         this.socialId = socialId;
         this.socialProvider = socialProvider;
+        this.role = role;
     }
 }

--- a/src/main/java/com/ktb/joing/domain/auth/redis/TempUser.java
+++ b/src/main/java/com/ktb/joing/domain/auth/redis/TempUser.java
@@ -1,0 +1,25 @@
+package com.ktb.joing.domain.auth.redis;
+
+import com.ktb.joing.domain.user.entity.SocialProvider;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash(value = "tempUser", timeToLive = 3600) // 1시간 후 만료
+public class TempUser {
+    @Id
+    private final String id; // socialProvider + " " + socialId 형식
+    private final String profileImage;
+    private final String socialId;
+    private final SocialProvider socialProvider;
+
+    @Builder
+    public TempUser(String id, String profileImage, String socialId, SocialProvider socialProvider) {
+        this.id = id;
+        this.profileImage = profileImage;
+        this.socialId = socialId;
+        this.socialProvider = socialProvider;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/auth/redis/TempUserRepository.java
+++ b/src/main/java/com/ktb/joing/domain/auth/redis/TempUserRepository.java
@@ -1,0 +1,6 @@
+package com.ktb.joing.domain.auth.redis;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface TempUserRepository extends CrudRepository<TempUser, String> {
+}

--- a/src/main/java/com/ktb/joing/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/ktb/joing/domain/auth/service/CustomOAuth2UserService.java
@@ -53,6 +53,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .profileImage(oAuth2Response.getProfileImage())
                     .socialId(oAuth2Response.getProviderId())
                     .socialProvider(SocialProvider.KAKAO)
+                    .role(Role.ROLE_USER)
                     .build();
 
             tempUserRepository.save(tempUser);

--- a/src/main/java/com/ktb/joing/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/ktb/joing/domain/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,85 @@
+package com.ktb.joing.domain.auth.service;
+
+import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
+import com.ktb.joing.domain.auth.dto.KakaoResponse;
+import com.ktb.joing.domain.auth.dto.OAuth2Response;
+import com.ktb.joing.domain.auth.dto.UserDto;
+import com.ktb.joing.domain.user.entity.ProductManager;
+import com.ktb.joing.domain.user.entity.Role;
+import com.ktb.joing.domain.user.entity.SocialProvider;
+import com.ktb.joing.domain.user.entity.User;
+import com.ktb.joing.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        log.info("OAuth2UserRequest={}", oAuth2User);
+
+        // 응답 데이터 받기
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2Response oAuth2Response = null;
+        if (registrationId.equals("kakao")) {
+            oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
+        }
+        else {
+            return null;
+        }
+
+        //리소스 서버에서 발급 받은 정보로 사용자를 특정할 아이디값을 만듬
+        String username = oAuth2Response.getProvider()+" "+oAuth2Response.getProviderId();
+        User existData = userRepository.findByUsername(username).orElse(null);
+
+        if (existData == null) {
+            User user = ProductManager.builder() // ProductManager로 임시 저장(회원가입 로직 후 변경 예정)
+                    .username(username)
+                    .email(oAuth2Response.getEmail())
+                    .nickname(oAuth2Response.getName())
+                    .profileImage(oAuth2Response.getProfileImage())
+                    .profileSetup(false)
+                    .role(Role.ROLE_USER)
+                    .socialId(oAuth2Response.getProviderId())
+                    .socialProvider(SocialProvider.KAKAO)
+                    .build();
+
+            userRepository.save(user);
+
+            UserDto userDto = new UserDto();
+            userDto.setUsername(username);
+            userDto.setName(oAuth2Response.getName());
+            userDto.setRole(Role.ROLE_USER);
+
+            return new CustomOAuth2User(userDto);
+        }
+        else {
+            existData.updateEmail(oAuth2Response.getEmail());
+            existData.updateNickname(oAuth2Response.getName());
+            existData.updateProfileImage(oAuth2Response.getProfileImage());
+
+            userRepository.save(existData);
+
+            UserDto userDto = new UserDto();
+            userDto.setUsername(existData.getUsername());
+            userDto.setName(oAuth2Response.getName());
+            userDto.setRole(existData.getRole());
+
+            return new CustomOAuth2User(userDto);
+        }
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/user/controller/UserController.java
+++ b/src/main/java/com/ktb/joing/domain/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.ktb.joing.domain.user.controller;
+
+import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
+import com.ktb.joing.domain.user.dto.request.CreatorSignupRequest;
+import com.ktb.joing.domain.user.dto.request.ProductManagerSignupRequest;
+import com.ktb.joing.domain.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/signup/creator")
+    public ResponseEntity<Void> creatorSignUp(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @RequestBody @Valid CreatorSignupRequest creatorSignupRequest) {
+
+        userService.creatorSignUp(customOAuth2User.getUsername(), creatorSignupRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/signup/productmanager")
+    public ResponseEntity<Void> productManagerSignUp(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @RequestBody @Valid ProductManagerSignupRequest productManagerSignupRequest){
+
+        userService.productManagerSignUp(customOAuth2User.getUsername(), productManagerSignupRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/user/dto/request/CreatorSignupRequest.java
+++ b/src/main/java/com/ktb/joing/domain/user/dto/request/CreatorSignupRequest.java
@@ -1,0 +1,36 @@
+package com.ktb.joing.domain.user.dto.request;
+
+import com.ktb.joing.domain.user.entity.Category;
+import com.ktb.joing.domain.user.entity.MediaType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreatorSignupRequest {
+
+    @NotBlank
+    private String nickname;
+
+    @NotBlank
+    @Email(regexp = "^[A-Za-z0-9+_.-]+@(.+)$", message = "올바른 이메일 형식이 아닙니다")
+    private String email;
+
+    private String channelUrl;
+    private MediaType mediaType;
+    private Category category;
+
+    @Builder
+    public CreatorSignupRequest(String nickname, String email, String channelUrl, MediaType mediaType, Category category) {
+        this.nickname = nickname;
+        this.email = email;
+        this.channelUrl = channelUrl;
+        this.mediaType = mediaType;
+        this.category = category;
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/user/dto/request/ProductManagerSignupRequest.java
+++ b/src/main/java/com/ktb/joing/domain/user/dto/request/ProductManagerSignupRequest.java
@@ -1,0 +1,34 @@
+package com.ktb.joing.domain.user.dto.request;
+
+import com.ktb.joing.domain.user.entity.Category;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductManagerSignupRequest {
+
+    @NotBlank
+    private String nickname;
+
+    @NotBlank
+    @Email(regexp = "^[A-Za-z0-9+_.-]+@(.+)$", message = "올바른 이메일 형식이 아닙니다")
+    private String email;
+
+    @NotNull
+    private List<Category> favoriteCategories;
+
+    @Builder
+    public ProductManagerSignupRequest(String nickname, String email, List<Category> favoriteCategories) {
+        this.nickname = nickname;
+        this.email = email;
+        this.favoriteCategories = favoriteCategories;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/user/entity/Category.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/Category.java
@@ -1,38 +1,26 @@
 package com.ktb.joing.domain.user.entity;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+public enum Category {
+    GAME("게임"),
+    TECH("과학기술"),
+    EDUCATION("교육"),
+    KNOWHOW_STYLE("노하우/스타일"),
+    NEWS_POLITICS("뉴스/정치"),
+    SPORTS("스포츠"),
+    NONPROFIT_SOCIAL("비영리/사회운동"),
+    PETS_ANIMALS("애완동물/동물"),
+    ENTERTAINMENT("엔터테인먼트"),
+    TRAVEL_EVENTS("여행/이벤트"),
+    MOVIE_ANIMATION("영화/애니메이션"),
+    MUSIC("음악"),
+    PEOPLE_BLOG("인물/블로그"),
+    AUTO_TRANSPORT("자동차/교통"),
+    COMEDY("코미디"),
+    ETC("기타");
 
-import java.util.ArrayList;
-import java.util.List;
+    private final String value;
 
-@Entity
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Category {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "category_id")
-    private Long id;
-
-    private String name;
-
-    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
-    private List<Creator> creators = new ArrayList<>();
-
-    @Builder
-    public Category(String name) {
-        this.name = name;
+    Category(String value) {
+        this.value = value;
     }
 }

--- a/src/main/java/com/ktb/joing/domain/user/entity/Category.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/Category.java
@@ -1,0 +1,38 @@
+package com.ktb.joing.domain.user.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
+    private List<Creator> creators = new ArrayList<>();
+
+    @Builder
+    public Category(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/user/entity/Creator.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/Creator.java
@@ -1,0 +1,54 @@
+package com.ktb.joing.domain.user.entity;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue(value = "Creator")
+public class Creator extends User{
+
+    private String channelUrl;
+
+    private Long maxViews;
+
+    private Long minViews;
+
+    private Long subscribers;
+
+    private Long comments;
+
+    @Enumerated(EnumType.STRING)
+    private MediaType mediaType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Builder
+    public Creator(String nickname, String email, String profileImage,
+                   Boolean profileSetup, String socialId, Role role,
+                   SocialProvider socialProvider, String channelUrl,
+                   Long maxViews, Long minViews, Long subscribers,
+                   Long comments, MediaType mediaType, Category category) {
+        super(nickname, email, profileImage, profileSetup, socialId, role, socialProvider);
+        this.channelUrl = channelUrl;
+        this.maxViews = maxViews;
+        this.minViews = minViews;
+        this.subscribers = subscribers;
+        this.comments = comments;
+        this.mediaType = mediaType;
+        this.category = category;
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/user/entity/Creator.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/Creator.java
@@ -12,7 +12,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DiscriminatorValue(value = "Creator")
@@ -31,8 +30,7 @@ public class Creator extends User{
     @Enumerated(EnumType.STRING)
     private MediaType mediaType;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id")
+    @Enumerated(EnumType.STRING)
     private Category category;
 
     @Builder

--- a/src/main/java/com/ktb/joing/domain/user/entity/Creator.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/Creator.java
@@ -36,12 +36,12 @@ public class Creator extends User{
     private Category category;
 
     @Builder
-    public Creator(String nickname, String email, String profileImage,
+    public Creator(String username, String nickname, String email, String profileImage,
                    Boolean profileSetup, String socialId, Role role,
                    SocialProvider socialProvider, String channelUrl,
                    Long maxViews, Long minViews, Long subscribers,
                    Long comments, MediaType mediaType, Category category) {
-        super(nickname, email, profileImage, profileSetup, socialId, role, socialProvider);
+        super(username, nickname, email, profileImage, profileSetup, socialId, role, socialProvider);
         this.channelUrl = channelUrl;
         this.maxViews = maxViews;
         this.minViews = minViews;

--- a/src/main/java/com/ktb/joing/domain/user/entity/Creator.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/Creator.java
@@ -4,17 +4,16 @@ import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
+@Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DiscriminatorValue(value = "Creator")
+@SuperBuilder
 public class Creator extends User{
 
     private String channelUrl;
@@ -32,21 +31,5 @@ public class Creator extends User{
 
     @Enumerated(EnumType.STRING)
     private Category category;
-
-    @Builder
-    public Creator(String username, String nickname, String email, String profileImage,
-                   Boolean profileSetup, String socialId, Role role,
-                   SocialProvider socialProvider, String channelUrl,
-                   Long maxViews, Long minViews, Long subscribers,
-                   Long comments, MediaType mediaType, Category category) {
-        super(username, nickname, email, profileImage, profileSetup, socialId, role, socialProvider);
-        this.channelUrl = channelUrl;
-        this.maxViews = maxViews;
-        this.minViews = minViews;
-        this.subscribers = subscribers;
-        this.comments = comments;
-        this.mediaType = mediaType;
-        this.category = category;
-    }
 
 }

--- a/src/main/java/com/ktb/joing/domain/user/entity/FavoriteCategory.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/FavoriteCategory.java
@@ -1,0 +1,39 @@
+package com.ktb.joing.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "favorite_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Builder
+    public FavoriteCategory(User user, Category category) {
+        this.user = user;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/user/entity/FavoriteCategory.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/FavoriteCategory.java
@@ -2,6 +2,8 @@ package com.ktb.joing.domain.user.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -27,8 +29,7 @@ public class FavoriteCategory {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id")
+    @Enumerated(EnumType.STRING)
     private Category category;
 
     @Builder

--- a/src/main/java/com/ktb/joing/domain/user/entity/MediaType.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/MediaType.java
@@ -1,0 +1,5 @@
+package com.ktb.joing.domain.user.entity;
+
+public enum MediaType {
+    SHORT_FORM, LONG_FORM
+}

--- a/src/main/java/com/ktb/joing/domain/user/entity/ProductManager.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/ProductManager.java
@@ -23,10 +23,10 @@ public class ProductManager extends User {
     private List<FavoriteCategory> favoriteCategories = new ArrayList<>();
 
     @Builder
-    public ProductManager(String nickname, String email, String profileImage,
+    public ProductManager(String username, String nickname, String email, String profileImage,
                           Boolean profileSetup, String socialId, Role role,
                           SocialProvider socialProvider) {
-        super(nickname, email, profileImage, profileSetup, socialId, role, socialProvider);
+        super(username, nickname, email, profileImage, profileSetup, socialId, role, socialProvider);
     }
 
 }

--- a/src/main/java/com/ktb/joing/domain/user/entity/ProductManager.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/ProductManager.java
@@ -1,0 +1,31 @@
+package com.ktb.joing.domain.user.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue(value = "ProductManager")
+public class ProductManager extends User {
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<FavoriteCategory> favoriteCategories = new ArrayList<>();
+
+    @Builder
+    public ProductManager(String nickname, String email, String profileImage,
+                          Boolean profileSetup, String socialId, Role role,
+                          SocialProvider socialProvider) {
+        super(nickname, email, profileImage, profileSetup, socialId, role, socialProvider);
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/user/entity/ProductManager.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/ProductManager.java
@@ -18,7 +18,8 @@ import java.util.List;
 @DiscriminatorValue(value = "ProductManager")
 public class ProductManager extends User {
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    //기획자가 삭제되면 해당 선호 카테고리도 삭제
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FavoriteCategory> favoriteCategories = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/ktb/joing/domain/user/entity/ProductManager.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/ProductManager.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,17 +17,13 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DiscriminatorValue(value = "ProductManager")
+@SuperBuilder
 public class ProductManager extends User {
 
     //기획자가 삭제되면 해당 선호 카테고리도 삭제
+    @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FavoriteCategory> favoriteCategories = new ArrayList<>();
 
-    @Builder
-    public ProductManager(String username, String nickname, String email, String profileImage,
-                          Boolean profileSetup, String socialId, Role role,
-                          SocialProvider socialProvider) {
-        super(username, nickname, email, profileImage, profileSetup, socialId, role, socialProvider);
-    }
 
 }

--- a/src/main/java/com/ktb/joing/domain/user/entity/Role.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/Role.java
@@ -1,0 +1,5 @@
+package com.ktb.joing.domain.user.entity;
+
+public enum Role {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/com/ktb/joing/domain/user/entity/SocialProvider.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/SocialProvider.java
@@ -1,0 +1,5 @@
+package com.ktb.joing.domain.user.entity;
+
+public enum SocialProvider {
+    KAKAO
+}

--- a/src/main/java/com/ktb/joing/domain/user/entity/User.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/User.java
@@ -11,22 +11,25 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 
 @Entity
 @Getter
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Inheritance(strategy = InheritanceType.JOINED)
-@DiscriminatorColumn(name = "USER_TYPE") // 자식을 구분할 수 있는 컬럼
+@Inheritance(strategy = InheritanceType.JOINED) // 상속 전략
+@DiscriminatorColumn(name = "user_type") // 자식을 구분할 수 있는 컬럼
 public abstract class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
+
+    private String username;
 
     private String nickname;
 
@@ -47,14 +50,17 @@ public abstract class User {
     @Column(nullable = false)
     private SocialProvider socialProvider;
 
-    @Builder
-    public User(String nickname, String email,  String profileImage, Boolean profileSetup, String socialId, Role role, SocialProvider socialProvider) {
+    // 자식 클래스에서 접근 가능한 protected 생성자
+    protected User(String username, String nickname, String email, String profileImage,
+                   Boolean profileSetup, String socialId, Role role,
+                   SocialProvider socialProvider) {
+        this.username = username;
         this.nickname = nickname;
         this.email = email;
         this.profileImage = profileImage;
         this.profileSetup = profileSetup;
-        this.role = role;
         this.socialId = socialId;
+        this.role = role;
         this.socialProvider = socialProvider;
     }
 
@@ -64,6 +70,10 @@ public abstract class User {
 
     public void updateEmail(String email) {
         this.email = email;
+    }
+
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
     }
 }
 

--- a/src/main/java/com/ktb/joing/domain/user/entity/User.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/User.java
@@ -1,0 +1,69 @@
+package com.ktb.joing.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "USER_TYPE") // 자식을 구분할 수 있는 컬럼
+public abstract class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    private String nickname;
+
+    private String email;
+
+    private String profileImage;
+
+    @Column(nullable = false)
+    private Boolean profileSetup;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Column(nullable = false)
+    private String socialId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SocialProvider socialProvider;
+
+    @Builder
+    public User(String nickname, String email,  String profileImage, Boolean profileSetup, String socialId, Role role, SocialProvider socialProvider) {
+        this.nickname = nickname;
+        this.email = email;
+        this.profileImage = profileImage;
+        this.profileSetup = profileSetup;
+        this.role = role;
+        this.socialId = socialId;
+        this.socialProvider = socialProvider;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+}
+

--- a/src/main/java/com/ktb/joing/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/ktb/joing/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,18 @@
+package com.ktb.joing.domain.user.exception;
+
+import com.ktb.joing.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+    // User Error
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저가 존재하지 않습니다"),
+    TEMP_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "임시 저장된 사용자 정보가 없습니다."),
+    DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/ktb/joing/domain/user/exception/UserException.java
+++ b/src/main/java/com/ktb/joing/domain/user/exception/UserException.java
@@ -1,0 +1,15 @@
+package com.ktb.joing.domain.user.exception;
+
+import com.ktb.joing.common.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class UserException extends BusinessException {
+    private final UserErrorCode userErrorCode;
+
+    public UserException(UserErrorCode userErrorCode) {
+        super(userErrorCode);
+        this.userErrorCode = userErrorCode;
+    }
+}
+

--- a/src/main/java/com/ktb/joing/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ktb/joing/domain/user/repository/UserRepository.java
@@ -3,5 +3,8 @@ package com.ktb.joing.domain.user.repository;
 import com.ktb.joing.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/ktb/joing/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ktb/joing/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.ktb.joing.domain.user.repository;
+
+import com.ktb.joing.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/ktb/joing/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ktb/joing/domain/user/repository/UserRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/ktb/joing/domain/user/service/UserService.java
+++ b/src/main/java/com/ktb/joing/domain/user/service/UserService.java
@@ -1,0 +1,91 @@
+package com.ktb.joing.domain.user.service;
+
+import com.ktb.joing.domain.auth.redis.TempUser;
+import com.ktb.joing.domain.auth.redis.TempUserRepository;
+import com.ktb.joing.domain.user.dto.request.CreatorSignupRequest;
+import com.ktb.joing.domain.user.dto.request.ProductManagerSignupRequest;
+import com.ktb.joing.domain.user.entity.Creator;
+import com.ktb.joing.domain.user.entity.FavoriteCategory;
+import com.ktb.joing.domain.user.entity.ProductManager;
+import com.ktb.joing.domain.user.entity.Role;
+import com.ktb.joing.domain.user.exception.UserErrorCode;
+import com.ktb.joing.domain.user.exception.UserException;
+import com.ktb.joing.domain.user.repository.UserRepository;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final TempUserRepository tempUserRepository;
+
+    public void creatorSignUp(String username, CreatorSignupRequest request) {
+        TempUser tempUser = tempUserRepository.findById(username)
+                .orElseThrow(() -> new UserException(UserErrorCode.TEMP_USER_NOT_FOUND));
+
+        validateDuplicateNickname(request.getNickname());
+
+        Creator creator = Creator.builder()
+                .username(tempUser.getId())
+                .email(request.getEmail())
+                .nickname(request.getNickname())
+                .profileImage(tempUser.getProfileImage())
+                .profileSetup(true)
+                .role(Role.ROLE_USER)
+                .socialId(tempUser.getSocialId())
+                .socialProvider(tempUser.getSocialProvider())
+                .channelUrl(request.getChannelUrl())
+                .mediaType(request.getMediaType())
+                .category(request.getCategory())
+                .build();
+
+        userRepository.save(creator);
+
+        tempUserRepository.deleteById(username);
+    }
+
+    public void productManagerSignUp(String username, ProductManagerSignupRequest request) {
+        TempUser tempUser = tempUserRepository.findById(username)
+                .orElseThrow(() -> new UserException(UserErrorCode.TEMP_USER_NOT_FOUND));
+
+        validateDuplicateNickname(request.getNickname());
+
+        ProductManager user = ProductManager.builder()
+                .username(tempUser.getId())
+                .profileImage(tempUser.getProfileImage())
+                .socialId(tempUser.getSocialId())
+                .socialProvider(tempUser.getSocialProvider())
+                .email(request.getEmail())
+                .nickname(request.getNickname())
+                .profileSetup(true)
+                .role(Role.ROLE_USER)
+                .build();
+
+        List<FavoriteCategory> favoriteCategories = request.getFavoriteCategories().stream()
+                .map(category -> FavoriteCategory.builder()
+                        .user(user)
+                        .category(category)
+                        .build())
+                .toList();
+
+        user.getFavoriteCategories().addAll(favoriteCategories);
+
+        userRepository.save(user);
+
+        tempUserRepository.deleteById(username);
+    }
+
+    // 닉네임 중복 확인
+    private void validateDuplicateNickname(String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw new UserException(UserErrorCode.DUPLICATED_NICKNAME);
+        }
+    }
+}
+

--- a/src/test/java/com/ktb/joing/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/ktb/joing/domain/user/service/UserServiceTest.java
@@ -1,0 +1,186 @@
+package com.ktb.joing.domain.user.service;
+
+import com.ktb.joing.domain.auth.redis.TempUser;
+import com.ktb.joing.domain.auth.redis.TempUserRepository;
+import com.ktb.joing.domain.user.dto.request.CreatorSignupRequest;
+import com.ktb.joing.domain.user.dto.request.ProductManagerSignupRequest;
+import com.ktb.joing.domain.user.entity.*;
+import com.ktb.joing.domain.user.exception.UserException;
+import com.ktb.joing.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+
+import static com.ktb.joing.domain.user.exception.UserErrorCode.DUPLICATED_NICKNAME;
+import static com.ktb.joing.domain.user.exception.UserErrorCode.TEMP_USER_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TempUserRepository tempUserRepository;
+
+    private TempUser tempUser;
+    private final String TEST_USERNAME = "KAKAO testSocialId"; // socialProvider + " " + socialId 형식
+
+    @BeforeEach
+    void setUp() {
+        // 각 테스트 전에 임시 유저 데이터 생성
+        tempUser = TempUser.builder()
+                .id(TEST_USERNAME)
+                .socialId("testSocialId")
+                .socialProvider(SocialProvider.KAKAO)
+                .profileImage("http://profile.image")
+                .role(Role.ROLE_USER)
+                .build();
+
+        tempUserRepository.save(tempUser);
+    }
+
+    @Test
+    @DisplayName("크리에이터 회원가입 성공")
+    void creatorSignUp_Success() {
+        // Given
+        CreatorSignupRequest request = CreatorSignupRequest.builder()
+                .nickname("creator")
+                .email("creator@test.com")
+                .channelUrl("http://youtube.com/creator")
+                .mediaType(MediaType.LONG_FORM)
+                .category(Category.ENTERTAINMENT)
+                .build();
+
+        // When
+        userService.creatorSignUp(TEST_USERNAME, request);
+
+        // Then
+        User savedUser = userRepository.findByUsername(TEST_USERNAME)
+                .orElseThrow(() -> new AssertionError("User not found"));
+
+        assertThat(savedUser).isInstanceOf(Creator.class);
+        Creator creator = (Creator) savedUser;
+
+        // 기본 정보 검증
+        assertThat(creator.getUsername()).isEqualTo(TEST_USERNAME);
+        assertThat(creator.getNickname()).isEqualTo("creator");
+        assertThat(creator.getEmail()).isEqualTo("creator@test.com");
+        assertThat(creator.getProfileImage()).isEqualTo(tempUser.getProfileImage());
+        assertThat(creator.getProfileSetup()).isTrue();
+        assertThat(creator.getRole()).isEqualTo(Role.ROLE_USER);
+        assertThat(creator.getSocialId()).isEqualTo(tempUser.getSocialId());
+        assertThat(creator.getSocialProvider()).isEqualTo(SocialProvider.KAKAO);
+
+        // 크리에이터 전용 정보 검증
+        assertThat(creator.getChannelUrl()).isEqualTo("http://youtube.com/creator");
+        assertThat(creator.getMediaType()).isEqualTo(MediaType.LONG_FORM);
+        assertThat(creator.getCategory()).isEqualTo(Category.ENTERTAINMENT);
+
+        // 임시 유저 데이터 삭제 확인
+        assertThat(tempUserRepository.findById(TEST_USERNAME)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기획자 회원가입 성공")
+    void productManagerSignUp_Success() {
+        // Given
+        ProductManagerSignupRequest request = ProductManagerSignupRequest.builder()
+                .nickname("manager")
+                .email("manager@test.com")
+                .favoriteCategories(Arrays.asList(Category.GAME, Category.TECH))
+                .build();
+
+        // When
+        userService.productManagerSignUp(TEST_USERNAME, request);
+
+        // Then
+        User savedUser = userRepository.findByUsername(TEST_USERNAME)
+                .orElseThrow(() -> new AssertionError("User not found"));
+
+        assertThat(savedUser).isInstanceOf(ProductManager.class);
+        ProductManager manager = (ProductManager) savedUser;
+
+        // 기본 정보 검증
+        assertThat(manager.getUsername()).isEqualTo(TEST_USERNAME);
+        assertThat(manager.getNickname()).isEqualTo("manager");
+        assertThat(manager.getEmail()).isEqualTo("manager@test.com");
+        assertThat(manager.getProfileImage()).isEqualTo(tempUser.getProfileImage());
+        assertThat(manager.getProfileSetup()).isTrue();
+        assertThat(manager.getRole()).isEqualTo(Role.ROLE_USER);
+        assertThat(manager.getSocialId()).isEqualTo(tempUser.getSocialId());
+        assertThat(manager.getSocialProvider()).isEqualTo(SocialProvider.KAKAO);
+
+        // 선호 카테고리 검증
+        assertThat(manager.getFavoriteCategories())
+                .hasSize(2)
+                .extracting(FavoriteCategory::getCategory)
+                .containsExactlyInAnyOrder(Category.GAME, Category.TECH);
+
+        // 임시 유저 데이터 삭제 확인
+        assertThat(tempUserRepository.findById(TEST_USERNAME)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("임시 유저가 없는 경우 회원가입 실패")
+    void signUp_FailWhenTempUserNotFound() {
+        // Given
+        String nonExistentUsername = "KAKAO nonExistent";
+        CreatorSignupRequest request = CreatorSignupRequest.builder()
+                .nickname("creator")
+                .email("creator@test.com")
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> userService.creatorSignUp(nonExistentUsername, request))
+                .isInstanceOf(UserException.class)
+                .hasFieldOrPropertyWithValue("userErrorCode", TEMP_USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("중복된 닉네임으로 회원가입 시도시 실패")
+    void signUp_FailWhenNicknameDuplicated() {
+        // Given
+        String duplicateNickname = "duplicate";
+
+        // 첫 번째 유저 생성
+        CreatorSignupRequest firstRequest = CreatorSignupRequest.builder()
+                .nickname(duplicateNickname)
+                .email("first@test.com")
+                .build();
+        userService.creatorSignUp(TEST_USERNAME, firstRequest);
+
+        // 두 번째 임시 유저 생성
+        String secondUsername = "KAKAO testSocialId2";
+        TempUser secondTempUser = TempUser.builder()
+                .id(secondUsername)
+                .socialId("testSocialId2")
+                .socialProvider(SocialProvider.KAKAO)
+                .profileImage("http://profile.image")
+                .role(Role.ROLE_USER)
+                .build();
+        tempUserRepository.save(secondTempUser);
+
+        // 두 번째 유저 생성 시도
+        CreatorSignupRequest secondRequest = CreatorSignupRequest.builder()
+                .nickname(duplicateNickname)
+                .email("second@test.com")
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> userService.creatorSignUp(secondUsername, secondRequest))
+                .isInstanceOf(UserException.class)
+                .hasFieldOrPropertyWithValue("userErrorCode", DUPLICATED_NICKNAME);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #JOING-18

<br/>

## 📝 작업 내용

> 카카오 소셜 로그인을 통해 사용자 인증을 수행하고, JWT(JSON Web Token)를 활용하여 인증 상태를 관리하는 기능입니다.
> 소셜 로그인 후 회원가입이 안되어있는 경우 기획자/ 크리에이터 정보를 받아 회원가입을 진행합니다.
> 회원가입 과정의 경우, 소셜 로그인을 통해 얻은 정보를 redis 임시저장소에 저장한 후 추가정보까지 입력 받아 최종 MYSQL DB에 저장합니다.
> 1시간만 임시 저장합니다.

<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 
