### PR TITLE
JOING-31 feat: 기획안 조회 API 구현

### DIFF
--- a/src/main/java/com/ktb/joing/domain/item/controller/ItemController.java
+++ b/src/main/java/com/ktb/joing/domain/item/controller/ItemController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,6 +30,12 @@ public class ItemController {
             @Valid @RequestBody ItemCreateRequest request) {
 
         ItemResponse response = itemService.createItem(request, customOAuth2User.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{itemId}")
+    public ResponseEntity<ItemResponse> getItem(@PathVariable Long itemId) {
+        ItemResponse response = itemService.getItem(itemId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/ktb/joing/domain/item/controller/ItemController.java
+++ b/src/main/java/com/ktb/joing/domain/item/controller/ItemController.java
@@ -3,6 +3,7 @@ package com.ktb.joing.domain.item.controller;
 import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
 import com.ktb.joing.domain.item.dto.request.ItemCreateRequest;
 import com.ktb.joing.domain.item.dto.request.ItemUpdateRequest;
+import com.ktb.joing.domain.item.dto.response.ItemRecentResponse;
 import com.ktb.joing.domain.item.dto.response.ItemResponse;
 import com.ktb.joing.domain.item.service.ItemService;
 import jakarta.validation.Valid;
@@ -17,6 +18,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,6 +39,13 @@ public class ItemController {
     @GetMapping("/{itemId}")
     public ResponseEntity<ItemResponse> getItem(@PathVariable Long itemId) {
         ItemResponse response = itemService.getItem(itemId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/recent")
+    public ResponseEntity<List<ItemRecentResponse>> getRecentItems(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        List<ItemRecentResponse> response = itemService.getRecentItems(customOAuth2User.getUsername());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/ktb/joing/domain/item/dto/response/ItemRecentResponse.java
+++ b/src/main/java/com/ktb/joing/domain/item/dto/response/ItemRecentResponse.java
@@ -1,0 +1,23 @@
+package com.ktb.joing.domain.item.dto.response;
+
+import com.ktb.joing.domain.item.entity.Item;
+import com.ktb.joing.domain.item.entity.Summary;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemRecentResponse {
+    private Long id;
+    private String title;
+    private Summary summary;
+
+    @Builder
+    public ItemRecentResponse(Item item) {
+        this.id = item.getId();
+        this.title = item.getTitle();
+        this.summary = item.getSummary();
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/ktb/joing/domain/item/repository/ItemRepository.java
@@ -3,5 +3,18 @@ package com.ktb.joing.domain.item.repository;
 import com.ktb.joing.domain.item.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    List<Item> findByUserUsernameAndCreatedDateTimeGreaterThanEqualOrderByCreatedDateTimeDesc(
+            String username, LocalDateTime startDate
+    );
+
+    default List<Item> findRecentItems(String username, LocalDateTime startDate) {
+        return findByUserUsernameAndCreatedDateTimeGreaterThanEqualOrderByCreatedDateTimeDesc(
+                username, startDate
+        );
+    }
 }

--- a/src/main/java/com/ktb/joing/domain/item/service/ItemService.java
+++ b/src/main/java/com/ktb/joing/domain/item/service/ItemService.java
@@ -64,6 +64,17 @@ public class ItemService {
                 .build();
     }
 
+    // 기획안 단 건 조회
+    @Transactional(readOnly = true)
+    public ItemResponse getItem(Long itemId) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new ItemException(ItemErrorCode.ITEM_NOT_FOUND));
+
+        return ItemResponse.builder()
+                .item(item)
+                .build();
+    }
+
     // 기획안 수정
     public ItemResponse updateItem(Long itemId, ItemUpdateRequest request, String username) {
         Item item = itemRepository.findById(itemId)

--- a/src/main/java/com/ktb/joing/domain/item/service/ItemService.java
+++ b/src/main/java/com/ktb/joing/domain/item/service/ItemService.java
@@ -2,6 +2,7 @@ package com.ktb.joing.domain.item.service;
 
 import com.ktb.joing.domain.item.dto.request.ItemCreateRequest;
 import com.ktb.joing.domain.item.dto.request.ItemUpdateRequest;
+import com.ktb.joing.domain.item.dto.response.ItemRecentResponse;
 import com.ktb.joing.domain.item.dto.response.ItemResponse;
 import com.ktb.joing.domain.item.entity.Etc;
 import com.ktb.joing.domain.item.entity.Item;
@@ -18,6 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -73,6 +76,24 @@ public class ItemService {
         return ItemResponse.builder()
                 .item(item)
                 .build();
+    }
+
+    // 기획안 리스트 조회 - 특정 기획자 사용자의 최근 3개월 기획안 기록 조회
+    public List<ItemRecentResponse> getRecentItems(String username) {
+        LocalDateTime threeMonthsAgo = LocalDateTime.now().minusMonths(3);
+
+        List<Item> recentItems = itemRepository.findRecentItems(
+                username,
+                threeMonthsAgo
+        );
+
+        return recentItems.isEmpty()
+                ? Collections.emptyList()
+                : recentItems.stream()
+                .map(item -> ItemRecentResponse.builder()
+                        .item(item)
+                        .build())
+                .toList();
     }
 
     // 기획안 수정


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #7 #JOING-31

<br/>

## 📝 작업 내용

> 기획안 단 건 조회 기능 및 특정 기획자 사용자의 최근 3개월 기획안 리스트 조회 기능입니다.

<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> Cascade 설정 재확인 및 Request, Response 혹은 불변 DTO의 경우 Record class로 수정할 예정입니다.
