### PR TITLE
JOING-35 feat: 기획안 평가 및 요약 생성 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,11 @@ dependencies {
 	//redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	//webflux (WebClient)
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	//swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
-
 
 	// spring cloud aws (aws parameter store)
 	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.2.1")

--- a/src/main/java/com/ktb/joing/common/config/WebClientConfig.java
+++ b/src/main/java/com/ktb/joing/common/config/WebClientConfig.java
@@ -1,0 +1,18 @@
+package com.ktb.joing.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/joing/common/exception/AiErrorCode.java
+++ b/src/main/java/com/ktb/joing/common/exception/AiErrorCode.java
@@ -1,0 +1,16 @@
+package com.ktb.joing.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AiErrorCode implements ErrorCode {
+    //AI
+    AI_BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "AI 서버와의 통신에 실패하였습니다."),
+    AI_SEVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI 서버 내부에서 에러가 발생하였습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/ktb/joing/common/exception/AiException.java
+++ b/src/main/java/com/ktb/joing/common/exception/AiException.java
@@ -1,0 +1,13 @@
+package com.ktb.joing.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AiException extends BusinessException {
+    private final AiErrorCode aiErrorCode;
+
+    public AiException(AiErrorCode aiErrorCode) {
+        super(aiErrorCode);
+        this.aiErrorCode = aiErrorCode;
+    }
+}

--- a/src/main/java/com/ktb/joing/common/util/webClient/ReactiveHttpService.java
+++ b/src/main/java/com/ktb/joing/common/util/webClient/ReactiveHttpService.java
@@ -1,0 +1,30 @@
+package com.ktb.joing.common.util.webClient;
+
+import com.ktb.joing.common.exception.AiErrorCode;
+import com.ktb.joing.common.exception.AiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class ReactiveHttpService {
+    private final WebClient webClient;
+
+     public <T, R> Mono<R> post(String url, T body, Class<R> responseType) {
+        return webClient.post()
+                .uri(url)
+                .bodyValue(body)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> {
+                    throw new AiException(AiErrorCode.AI_BAD_GATEWAY);
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> {
+                    throw new AiException(AiErrorCode.AI_SEVER_ERROR);
+                })
+                .bodyToMono(responseType);
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/item/controller/ItemEvaluationController.java
+++ b/src/main/java/com/ktb/joing/domain/item/controller/ItemEvaluationController.java
@@ -1,0 +1,29 @@
+package com.ktb.joing.domain.item.controller;
+
+import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
+import com.ktb.joing.domain.item.dto.response.EvaluationResponse;
+import com.ktb.joing.domain.item.service.ItemEvaluationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/items")
+public class ItemEvaluationController {
+    private final ItemEvaluationService itemEvaluationService;
+
+    @GetMapping("/{itemId}/evaluation")
+    public Mono<ResponseEntity<EvaluationResponse<?>>> requestEvaluation(
+            @PathVariable Long itemId,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+
+        return itemEvaluationService.requestEvaluation(itemId, customOAuth2User.getUsername())
+                .map(ResponseEntity::ok);
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/item/dto/request/ItemEvaluationRequest.java
+++ b/src/main/java/com/ktb/joing/domain/item/dto/request/ItemEvaluationRequest.java
@@ -1,0 +1,35 @@
+package com.ktb.joing.domain.item.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemEvaluationRequest {
+    private String title;
+    private String content;
+
+    @JsonProperty("media_type")
+    private String mediaType;
+
+    @JsonProperty("proposal_score")
+    private float proposalScore;
+
+    @JsonProperty("additional_Features")
+    private Map<String, String> additionalFeatures;
+
+    @Builder
+    public ItemEvaluationRequest(String title, String content, String mediaType,
+                                 float proposalScore, Map<String, String> additionalFeatures) {
+        this.title = title;
+        this.content = content;
+        this.mediaType = mediaType;
+        this.proposalScore = proposalScore;
+        this.additionalFeatures = additionalFeatures;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/item/dto/response/EvaluationResponse.java
+++ b/src/main/java/com/ktb/joing/domain/item/dto/response/EvaluationResponse.java
@@ -1,0 +1,14 @@
+package com.ktb.joing.domain.item.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class EvaluationResponse<T> {
+    private final ResponseType type;
+    private final T data;
+
+    public EvaluationResponse(ResponseType type, T data) {
+        this.type = type;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/item/dto/response/FeedbackResponse.java
+++ b/src/main/java/com/ktb/joing/domain/item/dto/response/FeedbackResponse.java
@@ -1,0 +1,25 @@
+package com.ktb.joing.domain.item.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FeedbackResponse {
+    @JsonProperty("feedback_type")
+    private int feedbackType;
+
+    @JsonProperty("current_score")
+    private float currentScore;
+
+    private String comment;
+    private List<String> violations;
+
+    public FeedbackView toView() {
+        return new FeedbackView(this.comment);
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/item/dto/response/FeedbackView.java
+++ b/src/main/java/com/ktb/joing/domain/item/dto/response/FeedbackView.java
@@ -1,0 +1,12 @@
+package com.ktb.joing.domain.item.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class FeedbackView {
+    private final String comment;
+
+    public FeedbackView(String comment) {
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/item/dto/response/ItemEvaluationResponse.java
+++ b/src/main/java/com/ktb/joing/domain/item/dto/response/ItemEvaluationResponse.java
@@ -1,0 +1,15 @@
+package com.ktb.joing.domain.item.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemEvaluationResponse {
+    @JsonProperty("evaluation_result")
+    private int evaluationResult;
+    private FeedbackResponse feedback;
+    private SummaryResponse summary;
+}

--- a/src/main/java/com/ktb/joing/domain/item/dto/response/ResponseType.java
+++ b/src/main/java/com/ktb/joing/domain/item/dto/response/ResponseType.java
@@ -1,0 +1,5 @@
+package com.ktb.joing.domain.item.dto.response;
+
+public enum ResponseType {
+    FEEDBACK, SUMMARY
+}

--- a/src/main/java/com/ktb/joing/domain/item/dto/response/SummaryResponse.java
+++ b/src/main/java/com/ktb/joing/domain/item/dto/response/SummaryResponse.java
@@ -1,0 +1,21 @@
+package com.ktb.joing.domain.item.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SummaryResponse {
+    private String title;
+    private String content;
+    @JsonProperty("keyword")
+    private List<String> keywords;
+
+    public SummaryView toView() {
+        return new SummaryView(this.title, this.content, this.keywords);
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/item/dto/response/SummaryView.java
+++ b/src/main/java/com/ktb/joing/domain/item/dto/response/SummaryView.java
@@ -1,0 +1,18 @@
+package com.ktb.joing.domain.item.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SummaryView {
+    private final String title;
+    private final String content;
+    private final List<String> keywords;
+
+    public SummaryView(String title, String content, List<String> keywords) {
+        this.title = title;
+        this.content = content;
+        this.keywords = keywords;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/item/entity/Item.java
+++ b/src/main/java/com/ktb/joing/domain/item/entity/Item.java
@@ -61,7 +61,7 @@ public class Item extends BaseTimeEntity {
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Etc> etcs = new ArrayList<>();
 
-    @OneToOne(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "item")
     private Summary summary;
 
     public void addEtc(Etc etc) {

--- a/src/main/java/com/ktb/joing/domain/item/entity/Summary.java
+++ b/src/main/java/com/ktb/joing/domain/item/entity/Summary.java
@@ -1,5 +1,6 @@
 package com.ktb.joing.domain.item.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -28,7 +29,7 @@ public class Summary {
 
     private String keyword;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "item_id")
     private Item item;
 

--- a/src/main/java/com/ktb/joing/domain/item/exception/ItemErrorCode.java
+++ b/src/main/java/com/ktb/joing/domain/item/exception/ItemErrorCode.java
@@ -12,7 +12,8 @@ public enum ItemErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저가 존재하지 않습니다"),
     INVALID_USER_TYPE(HttpStatus.BAD_REQUEST, "상품 기획자만 아이템을 생성할 수 있습니다"),
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "기획안을 찾을 수 없습니다."),
-    ITEM_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "해당 기획안에 대한 수정 권한이 없습니다.");
+    ITEM_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "해당 기획안에 대한 수정 권한이 없습니다."),
+    AI_EVALUATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 평가 요청에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/ktb/joing/domain/item/service/ItemEvaluationService.java
+++ b/src/main/java/com/ktb/joing/domain/item/service/ItemEvaluationService.java
@@ -1,0 +1,85 @@
+package com.ktb.joing.domain.item.service;
+
+import com.ktb.joing.common.util.webClient.ReactiveHttpService;
+import com.ktb.joing.domain.item.dto.request.ItemEvaluationRequest;
+import com.ktb.joing.domain.item.dto.response.EvaluationResponse;
+import com.ktb.joing.domain.item.dto.response.FeedbackView;
+import com.ktb.joing.domain.item.dto.response.ItemEvaluationResponse;
+import com.ktb.joing.domain.item.dto.response.ResponseType;
+import com.ktb.joing.domain.item.dto.response.SummaryView;
+import com.ktb.joing.domain.item.entity.Etc;
+import com.ktb.joing.domain.item.entity.Item;
+import com.ktb.joing.domain.item.exception.ItemErrorCode;
+import com.ktb.joing.domain.item.exception.ItemException;
+import com.ktb.joing.domain.item.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class ItemEvaluationService {
+
+    @Value("${ai.url}")
+    private String aiUrl;
+
+    private final ItemRepository itemRepository;
+    private final ReactiveHttpService reactiveHttpService;
+    private final ItemSummaryService itemSummaryService;
+
+    public Mono<EvaluationResponse<?>> requestEvaluation(Long itemId, String username) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new ItemException(ItemErrorCode.ITEM_NOT_FOUND));
+
+        if (!item.getUser().getUsername().equals(username)) {
+            throw new ItemException(ItemErrorCode.ITEM_NOT_AUTHORIZED);
+        }
+
+        ItemEvaluationRequest request = createEvaluationRequest(item);
+
+        return reactiveHttpService.post(
+                        aiUrl + "/ai/evaluation/proposal",
+                        request,
+                        ItemEvaluationResponse.class
+                )
+                .doOnSuccess(response -> {
+                    if (response.getEvaluationResult() == 1) {
+                        itemSummaryService.updateItemSummary(item, response.getSummary());
+                    }
+                })
+                .<EvaluationResponse<?>>map(this::convertToEvaluationResponse)
+                .doOnError(e -> log.error("AI 평가 요청 실패: {}", e.getMessage()))
+                .onErrorMap(e -> new ItemException(ItemErrorCode.AI_EVALUATION_FAILED));
+    }
+
+    private EvaluationResponse<?> convertToEvaluationResponse(ItemEvaluationResponse response) {
+        if (response.getEvaluationResult() == 0) {
+            return new EvaluationResponse<FeedbackView>(ResponseType.FEEDBACK,
+                    response.getFeedback().toView());
+        } else {
+            return new EvaluationResponse<SummaryView>(ResponseType.SUMMARY,
+                    response.getSummary().toView());
+        }
+    }
+
+    private ItemEvaluationRequest createEvaluationRequest(Item item) {
+        return ItemEvaluationRequest.builder()
+                .title(item.getTitle())
+                .content(item.getContent())
+                .mediaType(item.getMediaType().toString().toLowerCase())
+                .proposalScore(item.getScore())
+                .additionalFeatures(item.getEtcs().stream()
+                        .collect(Collectors.toMap(
+                                Etc::getName,
+                                Etc::getValue
+                        )))
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/item/service/ItemSummaryService.java
+++ b/src/main/java/com/ktb/joing/domain/item/service/ItemSummaryService.java
@@ -1,0 +1,26 @@
+package com.ktb.joing.domain.item.service;
+
+import com.ktb.joing.domain.item.dto.response.SummaryResponse;
+import com.ktb.joing.domain.item.entity.Item;
+import com.ktb.joing.domain.item.entity.Summary;
+import com.ktb.joing.domain.item.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ItemSummaryService {
+    private final ItemRepository itemRepository;
+
+    public void updateItemSummary(Item item, SummaryResponse summaryData) {
+        Summary summary = Summary.builder()
+                .title(summaryData.getTitle())
+                .content(summaryData.getContent())
+                .keyword(String.join(",", summaryData.getKeywords()))
+                .build();
+        item.setSummary(summary);
+        itemRepository.save(item);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #, #JOING-35

<br/>

## 📝 작업 내용

> 기획안 평가 및 요약 생성 기능 구현하였습니다.
> 클라이언트에서 백으로 요청이 들어오면, 백에서 AI 서버에 요청하여 기획안에 대한 평가와 요약을 가지고 옵니다.

<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 지금은 비동기 설정만해놓고 제대로 사용하지 않고 있습니다. 추후에 확실한 비동기 처리를 할 것 같습니다.
