### PR TITLE
JOING-36 refactor: Item의 getUser → getProductManager 변경 적용

### DIFF
--- a/src/main/java/com/ktb/joing/domain/item/service/ItemEvaluationService.java
+++ b/src/main/java/com/ktb/joing/domain/item/service/ItemEvaluationService.java
@@ -3,10 +3,8 @@ package com.ktb.joing.domain.item.service;
 import com.ktb.joing.common.util.webClient.ReactiveHttpService;
 import com.ktb.joing.domain.item.dto.request.ItemEvaluationRequest;
 import com.ktb.joing.domain.item.dto.response.EvaluationResponse;
-import com.ktb.joing.domain.item.dto.response.FeedbackView;
 import com.ktb.joing.domain.item.dto.response.ItemEvaluationResponse;
 import com.ktb.joing.domain.item.dto.response.ResponseType;
-import com.ktb.joing.domain.item.dto.response.SummaryView;
 import com.ktb.joing.domain.item.entity.Etc;
 import com.ktb.joing.domain.item.entity.Item;
 import com.ktb.joing.domain.item.exception.ItemErrorCode;
@@ -38,7 +36,7 @@ public class ItemEvaluationService {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new ItemException(ItemErrorCode.ITEM_NOT_FOUND));
 
-        if (!item.getUser().getUsername().equals(username)) {
+        if (!item.getProductManager().getUsername().equals(username)) {
             throw new ItemException(ItemErrorCode.ITEM_NOT_AUTHORIZED);
         }
 
@@ -61,10 +59,10 @@ public class ItemEvaluationService {
 
     private EvaluationResponse<?> convertToEvaluationResponse(ItemEvaluationResponse response) {
         if (response.getEvaluationResult() == 0) {
-            return new EvaluationResponse<FeedbackView>(ResponseType.FEEDBACK,
+            return new EvaluationResponse<>(ResponseType.FEEDBACK,
                     response.getFeedback().toView());
         } else {
-            return new EvaluationResponse<SummaryView>(ResponseType.SUMMARY,
+            return new EvaluationResponse<>(ResponseType.SUMMARY,
                     response.getSummary().toView());
         }
     }

--- a/src/main/java/com/ktb/joing/domain/item/service/ItemSummaryService.java
+++ b/src/main/java/com/ktb/joing/domain/item/service/ItemSummaryService.java
@@ -36,7 +36,7 @@ public class ItemSummaryService {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new ItemException(ItemErrorCode.ITEM_NOT_FOUND));
 
-        if (!item.getUser().getUsername().equals(username)) {
+        if (!item.getProductManager().getUsername().equals(username)) {
             throw new ItemException(ItemErrorCode.ITEM_NOT_AUTHORIZED);
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #21 , #JOING-36

<br/>

## 📝 작업 내용

> Item 엔티티의 getUser메서드를 getProductManager로 변경에 따른 서비스 로직 수정

<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 
