### PR TITLE
JOING-10 feat: 로그아웃 API 구현

### DIFF
--- a/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.ktb.joing.common.config;
 
 import com.ktb.joing.domain.auth.handler.CustomSuccessHandler;
+import com.ktb.joing.domain.auth.jwt.CustomLogoutFilter;
 import com.ktb.joing.domain.auth.jwt.JwtFilter;
 import com.ktb.joing.domain.auth.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -20,6 +22,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomSuccessHandler customSuccessHandler;
     private final JwtFilter jwtFilter;
+    private final CustomLogoutFilter customLogoutFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -45,6 +48,8 @@ public class SecurityConfig {
         // JWT 필터 설정
         http
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+        http
+                .addFilterBefore(customLogoutFilter, LogoutFilter.class);
 
         // 경로별 인가 작업
         http.securityMatcher("/**") // 모든 요청에 대해

--- a/src/main/java/com/ktb/joing/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/ktb/joing/domain/auth/exception/AuthErrorCode.java
@@ -12,6 +12,7 @@ public enum AuthErrorCode implements ErrorCode {
     // Auth Error
     OAUTH2_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "로그인 실패"),
     INVALID_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰을 찾을 수 없습니다"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
     TEMP_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "임시 사용자 정보를 찾을 수 없습니다"),
     HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다"),

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/CustomLogoutFilter.java
@@ -1,0 +1,77 @@
+package com.ktb.joing.domain.auth.jwt;
+
+import com.ktb.joing.domain.auth.cookie.CookieUtils;
+import com.ktb.joing.domain.auth.exception.AuthErrorCode;
+import com.ktb.joing.domain.auth.exception.AuthException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends OncePerRequestFilter {
+
+    private static final String LOGOUT_PATH = "/api/v1/logout";
+
+    private final JwtUtil jwtUtils;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final CookieUtils cookieUtils;
+
+    // 로그아웃 요청을 처리하는 필터 메서드
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        if (!isLogoutRequest(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            String refreshToken = cookieUtils.getCookie(request, "refresh")
+                    .orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_JWT))
+                    .getValue();
+
+            validateRefreshToken(refreshToken);
+            processLogout(refreshToken, request, response);
+            response.setStatus(HttpServletResponse.SC_OK);
+
+        } catch (AuthException e) {
+            log.error("Logout failed: {}", e.getMessage());
+            response.setStatus(e.getAuthErrorCode().getHttpStatus().value());
+        }
+    }
+
+    // 현재 요청이 로그아웃 요청인지 확인
+    private boolean isLogoutRequest(HttpServletRequest request) {
+        return request.getRequestURI().equals(LOGOUT_PATH)
+                && request.getMethod().equals(HttpMethod.POST.name());
+    }
+
+    // Refresh 토큰의 유효성을 검증
+    private void validateRefreshToken(String refreshToken) {
+        if (!jwtUtils.isTokenValid(refreshToken)) {
+            throw new AuthException(AuthErrorCode.INVALID_JWT);
+        }
+
+        if (!refreshTokenRepository.existsById(refreshToken)) {
+            throw new AuthException(AuthErrorCode.TOKEN_NOT_FOUND);
+        }
+    }
+
+    // 실제 로그아웃 처리를 수행 (Redis에서 refresh 토큰을 삭제하고 쿠키를 제거)
+    private void processLogout(String refreshToken, HttpServletRequest request, HttpServletResponse response) {
+        refreshTokenRepository.deleteById(refreshToken);
+        cookieUtils.deleteCookie(request, response, "refresh");
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/user/controller/UserController.java
+++ b/src/main/java/com/ktb/joing/domain/user/controller/UserController.java
@@ -37,4 +37,5 @@ public class UserController {
         userService.productManagerSignUp(customOAuth2User.getUsername(), productManagerSignupRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #4 #JOING-10

<br/>

## 📝 작업 내용

> 로그아웃시 redis에 있는 refresh 토큰과 쿠키를 제거하도록 로그아웃 기능을 구현하였습니다.
> 그리고 프론트로 리다이렉트 시 헤더에 있는 토큰이 전달되지 않아서 액세스 토큰 전달 방식을 헤더에서 URL 쿼리 파라미터로 변경하여 문제를 해결하였습니다.

<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 
