### PR TITLE
JOING-49 feat: JWT 인증 관련 버그 수정

### DIFF
--- a/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
         http.securityMatcher("/**") // 모든 요청에 대해
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/healthz", "/oauth2/**", "/login/**").permitAll()
-                        .requestMatchers("/api/v1/users/signup/**").hasAuthority("TEMP_USER")
+                        .requestMatchers("/api/v1/users/signup/**").hasRole("TEMP_USER")
                         .anyRequest().authenticated()
                 );
 
@@ -95,4 +95,5 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
+
 }

--- a/src/main/java/com/ktb/joing/domain/auth/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/ktb/joing/domain/auth/handler/CustomSuccessHandler.java
@@ -66,6 +66,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String refresh = jwtUtil.createTempRefreshToken("refresh", username, role);
         tokenService.saveRefreshToken(username, refresh);
         response.addCookie(cookieUtils.createCookie("refresh", refresh));
+        log.info("access token: {}", access);
+        log.info("refresh token: {}", refresh);
 
         return UriComponentsBuilder.fromUriString(frontUrl + "/signup")
                 .queryParam("token", access)
@@ -79,6 +81,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String refresh = jwtUtil.createRefreshToken("refresh", username, role);
         tokenService.saveRefreshToken(username, refresh);
         response.addCookie(cookieUtils.createCookie("refresh", refresh));
+        log.info("access token: {}", access);
+        log.info("refresh token: {}", refresh);
 
         return UriComponentsBuilder.fromUriString(frontUrl)
                 .queryParam("token", access)

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/JwtFilter.java
@@ -1,8 +1,11 @@
 package com.ktb.joing.domain.auth.jwt;
 
 import com.ktb.joing.domain.auth.cookie.CookieUtils;
+import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
+import com.ktb.joing.domain.auth.dto.UserDto;
 import com.ktb.joing.domain.auth.exception.AuthErrorCode;
 import com.ktb.joing.domain.auth.exception.AuthException;
+import com.ktb.joing.domain.user.entity.Role;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -13,12 +16,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Optional;
 
 @Component
@@ -28,10 +31,30 @@ public class JwtFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private final CookieUtils cookieUtils;
     private final TokenService tokenService;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher(); // 추가
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        // 인증이 필요없는 경로들 정의
+        String[] permitUrls = {
+                "/",
+                "/healthz",
+                "/oauth2/**",
+                "/login/**",
+                "/favicon.ico"
+        };
+
+        boolean result = Arrays.stream(permitUrls)
+                .anyMatch(permitUrl -> pathMatcher.match(permitUrl, path));
+
+        log.info("JwtFilter shouldNotFilter({}) : {}", path, result);
+        return result;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-
+        log.info("Request URI: {}", request.getRequestURI()); //첫 진입점에서 요청 정보 확인
         // jwt 기간 만료시, 무한 재로그인 방지 로직
         if (isOAuth2RelatedPath(request)) {
             filterChain.doFilter(request, response);
@@ -41,78 +64,74 @@ public class JwtFilter extends OncePerRequestFilter {
         String accessToken = request.getHeader("access");
         Optional<Cookie> refreshTokenCookie = cookieUtils.getCookie(request, "refresh");
         String refreshToken = refreshTokenCookie.map(Cookie::getValue).orElse(null);
+        log.info("Access token: {}", accessToken);
+        log.info("Refresh token: {}", refreshToken);
 
-        try {
-            // 1. 토큰이 모두 없는 경우
-            if (accessToken == null && refreshToken == null) {
-                log.info("No tokens present");
-                filterChain.doFilter(request, response);
-                return;
-            }
-
-            // 2. Access 토큰 카테고리 검증
-            if (accessToken != null && !jwtUtil.getCategoryFromToken(accessToken).equals("access")) {
-                log.error("Invalid access token category");
-                throw new AuthException(AuthErrorCode.INVALID_JWT);
-            }
-
-            // 3. Access 토큰이 유효한 경우
-            if (accessToken != null && jwtUtil.isTokenValid(accessToken)) {
-                log.info("Valid access token");
-                setAuthentication(
-                        jwtUtil.getUsernameFromToken(accessToken),
-                        jwtUtil.getRoleFromToken(accessToken)
-                );
-                filterChain.doFilter(request, response);
-                return;
-            }
-
-            // 4. Access 토큰이 만료되고 Refresh 토큰이 유효한 경우
-            if (refreshToken != null && jwtUtil.isTokenValid(refreshToken)) {
-                log.info("Access token expired, but refresh token valid");
-                String newAccessToken = tokenService.reissueAccessToken(response, refreshToken);
-                setAuthentication(
-                        jwtUtil.getUsernameFromToken(newAccessToken),
-                        jwtUtil.getRoleFromToken(newAccessToken)
-                );
-                filterChain.doFilter(request, response);
-                return;
-            }
-
-            // 5. Refresh 토큰도 만료된 경우
-            if (refreshToken != null) {
-                log.info("Both tokens expired");
-                cookieUtils.deleteCookie(request, response, "refresh");
-                tokenService.deleteRefreshToken(refreshToken);
-            }
-
-            // 6. 그 외의 경우 (유효하지 않은 토큰)
-            log.info("Invalid tokens");
+        // 1. 토큰이 모두 없는 경우
+        if (accessToken == null && refreshToken == null) {
+            log.info("No tokens present");
             filterChain.doFilter(request, response);
-
-        } catch (Exception e) {
-            log.error("JWT Filter Error", e);
-            cookieUtils.deleteCookie(request, response, "refresh");
-            throw e;
+            return;
         }
+
+        // 2. Access 토큰 카테고리 검증
+        if (accessToken != null && !jwtUtil.getCategoryFromToken(accessToken).equals("access")) {
+            log.error("Invalid access token category");
+            throw new AuthException(AuthErrorCode.INVALID_JWT);
+        }
+
+        // 3. Access 토큰이 유효한 경우
+        if (accessToken != null && jwtUtil.isTokenValid(accessToken)) {
+            log.info("Valid access token");
+            setAuthentication(
+                    jwtUtil.getUsernameFromToken(accessToken),
+                    jwtUtil.getRoleFromToken(accessToken)
+            );
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 4. Access 토큰이 만료되고 Refresh 토큰이 유효한 경우
+        if (refreshToken != null && jwtUtil.isTokenValid(refreshToken)) {
+            log.info("Access token expired, but refresh token valid");
+            String newAccessToken = tokenService.reissueAccessToken(response, refreshToken);
+            setAuthentication(
+                    jwtUtil.getUsernameFromToken(newAccessToken),
+                    jwtUtil.getRoleFromToken(newAccessToken)
+            );
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 5. Refresh 토큰도 만료된 경우
+        if (refreshToken != null) {
+            log.info("Both tokens expired");
+            cookieUtils.deleteCookie(request, response, "refresh");
+            tokenService.deleteRefreshToken(refreshToken);
+        }
+
+        // 6. 그 외의 경우 (유효하지 않은 토큰)
+        log.info("Invalid tokens");
+        filterChain.doFilter(request, response);
+
     }
 
     //jwt 기간 만료시, 무한 재로그인 방지 로직
     private boolean isOAuth2RelatedPath(HttpServletRequest request) {
         String requestUri = request.getRequestURI();
-        return requestUri.matches("^\\/login(?:\\/.*)?$") ||
-                requestUri.matches("^\\/oauth2(?:\\/.*)?$");
+        return requestUri.matches("^/login(?:/.*)?$") ||
+                requestUri.matches("^/oauth2(?:/.*)?$");
     }
 
 
     private void setAuthentication(String username, String role) {
-        UserDetails userDetails = createUserDetails(username, role);
+        CustomOAuth2User userDetails = createUserDetails(username, role);
         Authentication authentication = getAuthentication(userDetails);
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     //스프링 시큐리티 인증 토큰 생성
-    private Authentication getAuthentication(UserDetails userDetails){
+    private Authentication getAuthentication(CustomOAuth2User userDetails){
         return new UsernamePasswordAuthenticationToken(
                 userDetails,
                 null,
@@ -121,11 +140,11 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     // UserDetails 객체 생성
-    private UserDetails createUserDetails(String username, String role) {
-        return User.builder()
-                .username(username)
-                .password("")
-                .authorities(role)
-                .build();
+    private CustomOAuth2User createUserDetails(String username, String role) {
+        UserDto userDto = new UserDto();
+        userDto.setUsername(username);
+        userDto.setRole(Role.valueOf(role));
+        return new CustomOAuth2User(userDto);
     }
+
 }

--- a/src/main/java/com/ktb/joing/domain/auth/jwt/TokenService.java
+++ b/src/main/java/com/ktb/joing/domain/auth/jwt/TokenService.java
@@ -82,5 +82,4 @@ public class TokenService {
         refreshTokenRepository.deleteById(refreshToken);
     }
 
-
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #JOING-49

<br/>

## 📝 작업 내용

> 로그인을 시도 하지 않고 로그인 페이지로 이동만 했는데도 오류가 떴었습니다.
> 문제 상황을 파악해보니 이전에 로그인했을 때의 refresh 토큰이 쿠키에 남아있었고 JwtFilter가 이 토큰을 가지고 불필요한 검증을 시도하다가 에러 발생한 것이였습니다.
> 이를 해결하기 위해 로그인 페이지 접근 시 기존 토큰들을 정리하도록 JwtFilter에 shouldNotFilter() 메서드를 추가하여 로그인 페이지에 접근할 때마다 이전 세션의 토큰들이 정리되어, 불필요한 토큰 검증으로 인한 에러를 방지 하였습니다.
> SecurityConfig에서 hasAuthority("TEMP_USER")를 사용했을 때, JWT 토큰의 'ROLE_TEMP_USER' 권한과 문자열이 정확히 일치하지 않아 인증에 실패하는 문제가 있었습니다. 
> hasRole("TEMP_USER")로 변경하여 Spring Security가 자동으로 'ROLE_' prefix를 추가하도록 함으로써 권한 검증이 정상적으로 동작하도록 수정했습니다.
> 이를 통해 권한 문자열 일치 문제 해결하였습니다.
<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 
