### PR TITLE
JOING-58 feat: 추천 시스템 API 구현

### DIFF
--- a/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/users/evaluation/**").permitAll() // AI 서버 관련 엔드 포인트
                         .requestMatchers("/api/v1/items/*/evaluation").permitAll()
                         .requestMatchers("/api/v1/items/*/summary").permitAll()
+                        .requestMatchers("/api/v1/recommendations/**").permitAll()
                         .requestMatchers("/signup/**", "/api/v1/users/signup/**").hasRole("TEMP_USER")
                         .anyRequest().authenticated()
                 );

--- a/src/main/java/com/ktb/joing/common/config/WebClientConfig.java
+++ b/src/main/java/com/ktb/joing/common/config/WebClientConfig.java
@@ -1,9 +1,13 @@
 package com.ktb.joing.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.Jackson2JsonEncoder;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
@@ -11,8 +15,14 @@ public class WebClientConfig {
 
     @Bean
     public WebClient webClient() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
         return WebClient.builder()
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .codecs(configurer -> {
+                    configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper));
+                    configurer.defaultCodecs().jackson2JsonEncoder(new Jackson2JsonEncoder(objectMapper));
+                })
                 .build();
     }
 }

--- a/src/main/java/com/ktb/joing/domain/item/dto/request/ItemEvaluationRequest.java
+++ b/src/main/java/com/ktb/joing/domain/item/dto/request/ItemEvaluationRequest.java
@@ -1,26 +1,21 @@
 package com.ktb.joing.domain.item.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.Map;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class ItemEvaluationRequest {
     private String title;
     private String content;
-
-    @JsonProperty("media_type")
     private String mediaType;
-
-    @JsonProperty("proposal_score")
     private float proposalScore;
-
-    @JsonProperty("additional_features")
     private Map<String, String> additionalFeatures;
 
     @Builder

--- a/src/main/java/com/ktb/joing/domain/item/dto/response/FeedbackResponse.java
+++ b/src/main/java/com/ktb/joing/domain/item/dto/response/FeedbackResponse.java
@@ -1,6 +1,5 @@
 package com.ktb.joing.domain.item.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,12 +9,8 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FeedbackResponse {
-    @JsonProperty("feedback_type")
     private int feedbackType;
-
-    @JsonProperty("current_score")
     private float currentScore;
-
     private String comment;
     private List<String> violations;
 

--- a/src/main/java/com/ktb/joing/domain/item/dto/response/ItemEvaluationResponse.java
+++ b/src/main/java/com/ktb/joing/domain/item/dto/response/ItemEvaluationResponse.java
@@ -1,6 +1,5 @@
 package com.ktb.joing.domain.item.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +7,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ItemEvaluationResponse {
-    @JsonProperty("evaluation_result")
     private int evaluationResult;
     private FeedbackResponse feedback;
     private SummaryResponse summary;

--- a/src/main/java/com/ktb/joing/domain/item/exception/ItemErrorCode.java
+++ b/src/main/java/com/ktb/joing/domain/item/exception/ItemErrorCode.java
@@ -12,7 +12,7 @@ public enum ItemErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저가 존재하지 않습니다"),
     INVALID_USER_TYPE(HttpStatus.BAD_REQUEST, "상품 기획자만 아이템을 생성할 수 있습니다"),
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "기획안을 찾을 수 없습니다."),
-    ITEM_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "해당 기획안에 대한 수정 권한이 없습니다."),
+    ITEM_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "해당 기획안에 대한 권한이 없습니다."),
     AI_EVALUATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 평가 요청에 실패했습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/ktb/joing/domain/recommend/client/RecommendAIClient.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/client/RecommendAIClient.java
@@ -23,7 +23,7 @@ public class RecommendAIClient {
     // 기획안으로 -> 크리에이터 추천 받음
     public Mono<CreatorRecommendResponse> requestCreatorRecommend(CreatorRecommendRequest request) {
         return reactiveHttpService.post(
-                aiUrl + "/rec/recommend/item",
+                aiUrl + "/rec/recommend/creator",
                 request,
                 CreatorRecommendResponse.class
         ).doOnError(e -> log.error("AI 크리에이터 추천 요청 실패: {}", e.getMessage()));
@@ -32,7 +32,7 @@ public class RecommendAIClient {
     // 크리에이터로 -> 기획안 추천 받음
     public Mono<ItemRecommendResponse> requestItemRecommend(ItemRecommendRequest request){
         return reactiveHttpService.post(
-            aiUrl + "/rec/recommend/creator",
+            aiUrl + "/rec/recommend/item",
                 request,
                 ItemRecommendResponse.class
         ).doOnError(e -> log.error("AI 기획안 추천 요청 실패: {}", e.getMessage()));

--- a/src/main/java/com/ktb/joing/domain/recommend/client/RecommendAIClient.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/client/RecommendAIClient.java
@@ -1,0 +1,40 @@
+package com.ktb.joing.domain.recommend.client;
+
+import com.ktb.joing.common.util.webClient.ReactiveHttpService;
+import com.ktb.joing.domain.recommend.dto.request.CreatorRecommendRequest;
+import com.ktb.joing.domain.recommend.dto.request.ItemRecommendRequest;
+import com.ktb.joing.domain.recommend.dto.response.CreatorRecommendResponse;
+import com.ktb.joing.domain.recommend.dto.response.ItemRecommendResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RecommendAIClient {
+    @Value("${ai.url}")
+    private String aiUrl;
+
+    private final ReactiveHttpService reactiveHttpService;
+
+    // 기획안으로 -> 크리에이터 추천 받음
+    public Mono<CreatorRecommendResponse> requestCreatorRecommend(CreatorRecommendRequest request) {
+        return reactiveHttpService.post(
+                aiUrl + "/rec/recommend/item",
+                request,
+                CreatorRecommendResponse.class
+        ).doOnError(e -> log.error("AI 크리에이터 추천 요청 실패: {}", e.getMessage()));
+    }
+
+    // 크리에이터로 -> 기획안 추천 받음
+    public Mono<ItemRecommendResponse> requestItemRecommend(ItemRecommendRequest request){
+        return reactiveHttpService.post(
+            aiUrl + "/rec/recommend/creator",
+                request,
+                ItemRecommendResponse.class
+        ).doOnError(e -> log.error("AI 기획안 추천 요청 실패: {}", e.getMessage()));
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/recommend/controller/RecommendController.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/controller/RecommendController.java
@@ -1,0 +1,35 @@
+package com.ktb.joing.domain.recommend.controller;
+
+import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
+import com.ktb.joing.domain.recommend.dto.response.CreatorRecommendResponse;
+import com.ktb.joing.domain.recommend.dto.response.ItemRecommendResponse;
+import com.ktb.joing.domain.recommend.service.RecommendService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/recommendations")
+public class RecommendController {
+    private final RecommendService recommendService;
+
+    @GetMapping("/items/{itemId}")
+    public Mono<ResponseEntity<CreatorRecommendResponse>> getRecommendedCreators(@PathVariable @Valid Long itemId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return recommendService.getRecommendedCreators(itemId, customOAuth2User.getUsername())
+                .map(ResponseEntity::ok);
+    }
+
+    @GetMapping("/users/{userId}")
+    public  Mono<ResponseEntity<ItemRecommendResponse>> getRecommendedItems(@PathVariable @Valid Long userId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return recommendService.getRecommendedItems(userId, customOAuth2User.getUsername())
+                .map(ResponseEntity::ok); // 수정
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/recommend/controller/RecommendController.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/controller/RecommendController.java
@@ -29,7 +29,7 @@ public class RecommendController {
     @GetMapping("/users/{userId}")
     public  Mono<ResponseEntity<ItemRecommendResponse>> getRecommendedItems(@PathVariable @Valid Long userId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         return recommendService.getRecommendedItems(userId, customOAuth2User.getUsername())
-                .map(ResponseEntity::ok); // 수정
+                .map(ResponseEntity::ok);
     }
 
 }

--- a/src/main/java/com/ktb/joing/domain/recommend/dto/request/CreatorRecommendRequest.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/dto/request/CreatorRecommendRequest.java
@@ -1,0 +1,29 @@
+package com.ktb.joing.domain.recommend.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreatorRecommendRequest {
+    private String title;
+    @JsonProperty("item_Category")
+    private String category;
+    @JsonProperty("media_type")
+    private String mediaType;
+    private float score;
+    @JsonProperty("item_content")
+    private String content;
+
+    @Builder
+    public CreatorRecommendRequest(String title, String category, String mediaType, float score, String content){
+        this.title = title;
+        this.category = category;
+        this.mediaType = mediaType;
+        this.score = score;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/recommend/dto/request/CreatorRecommendRequest.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/dto/request/CreatorRecommendRequest.java
@@ -10,9 +10,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreatorRecommendRequest {
     private String title;
-    @JsonProperty("item_Category")
+    @JsonProperty("item_category")
     private String category;
-    @JsonProperty("media_type")
     private String mediaType;
     private float score;
     @JsonProperty("item_content")

--- a/src/main/java/com/ktb/joing/domain/recommend/dto/request/ItemRecommendRequest.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/dto/request/ItemRecommendRequest.java
@@ -1,0 +1,24 @@
+package com.ktb.joing.domain.recommend.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemRecommendRequest {
+    @JsonProperty("channel_name")
+    private String nickname;
+    @JsonProperty("channel_category")
+    private String category;
+    private Long subscribers;
+
+    @Builder
+    public ItemRecommendRequest(String nickname, String category, Long subscribers) {
+        this.nickname = nickname;
+        this.category = category;
+        this.subscribers = subscribers;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/recommend/dto/response/CreatorRecommend.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/dto/response/CreatorRecommend.java
@@ -1,0 +1,18 @@
+package com.ktb.joing.domain.recommend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreatorRecommend {
+    @JsonProperty("creator_id")
+    private Long creatorId;
+    @JsonProperty("channel_category")
+    private String category;
+    @JsonProperty("channel_name")
+    private String nickname;
+    private Long subscribers;
+}

--- a/src/main/java/com/ktb/joing/domain/recommend/dto/response/CreatorRecommendResponse.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/dto/response/CreatorRecommendResponse.java
@@ -1,0 +1,15 @@
+package com.ktb.joing.domain.recommend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreatorRecommendResponse {
+    @JsonProperty("recommend_creators")
+    private List<CreatorRecommend> recommendCreators;
+}

--- a/src/main/java/com/ktb/joing/domain/recommend/dto/response/CreatorRecommendResponse.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/dto/response/CreatorRecommendResponse.java
@@ -1,6 +1,5 @@
 package com.ktb.joing.domain.recommend.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +9,5 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreatorRecommendResponse {
-    @JsonProperty("recommend_creators")
-    private List<CreatorRecommend> recommendCreators;
+    private List<CreatorRecommend> recommendedCreators;
 }

--- a/src/main/java/com/ktb/joing/domain/recommend/dto/response/ItemRecommend.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/dto/response/ItemRecommend.java
@@ -1,0 +1,19 @@
+package com.ktb.joing.domain.recommend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemRecommend {
+    @JsonProperty("item_id")
+    private Long itemId;
+    private String title;
+    @JsonProperty("media_type")
+    private String mediaType;
+    private int score;
+    @JsonProperty("item_content")
+    private String content;
+}

--- a/src/main/java/com/ktb/joing/domain/recommend/dto/response/ItemRecommendResponse.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/dto/response/ItemRecommendResponse.java
@@ -1,6 +1,5 @@
 package com.ktb.joing.domain.recommend.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +9,5 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ItemRecommendResponse {
-    @JsonProperty("recommend_items")
-    private List<ItemRecommend> recommendItems;
+    private List<ItemRecommend> recommendedItems;
 }

--- a/src/main/java/com/ktb/joing/domain/recommend/dto/response/ItemRecommendResponse.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/dto/response/ItemRecommendResponse.java
@@ -1,0 +1,15 @@
+package com.ktb.joing.domain.recommend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemRecommendResponse {
+    @JsonProperty("recommend_items")
+    private List<ItemRecommend> recommendItems;
+}

--- a/src/main/java/com/ktb/joing/domain/recommend/exception/RecommendErrorCode.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/exception/RecommendErrorCode.java
@@ -1,0 +1,16 @@
+package com.ktb.joing.domain.recommend.exception;
+
+import com.ktb.joing.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RecommendErrorCode implements ErrorCode {
+    // Recommend Error
+    AI_RECOMMEND_FAILED(HttpStatus.BAD_GATEWAY, "AI 추천 요청에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/ktb/joing/domain/recommend/exception/RecommendException.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/exception/RecommendException.java
@@ -1,0 +1,14 @@
+package com.ktb.joing.domain.recommend.exception;
+
+import com.ktb.joing.common.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class RecommendException extends BusinessException {
+    private final RecommendErrorCode recommendErrorCode;
+
+    public RecommendException(RecommendErrorCode recommendErrorCode) {
+        super(recommendErrorCode);
+        this.recommendErrorCode = recommendErrorCode;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/recommend/service/RecommendService.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/service/RecommendService.java
@@ -12,6 +12,7 @@ import com.ktb.joing.domain.recommend.dto.response.ItemRecommendResponse;
 import com.ktb.joing.domain.recommend.exception.RecommendErrorCode;
 import com.ktb.joing.domain.recommend.exception.RecommendException;
 import com.ktb.joing.domain.user.entity.Creator;
+import com.ktb.joing.domain.user.entity.MediaType;
 import com.ktb.joing.domain.user.exception.UserErrorCode;
 import com.ktb.joing.domain.user.exception.UserException;
 import com.ktb.joing.domain.user.repository.CreatorRepository;
@@ -66,10 +67,13 @@ public class RecommendService {
     }
 
     private CreatorRecommendRequest creatorRecommendRequest(Item item) {
+        String mediaType = null;
+        if (item.getMediaType()==MediaType.LONG_FORM) mediaType = "long";
+        else if (item.getMediaType()==MediaType.SHORT_FORM) mediaType = "short";
         return CreatorRecommendRequest.builder()
                 .title(item.getTitle())
                 .category(item.getCategory().toString().toLowerCase())
-                .mediaType(item.getMediaType().toString().toLowerCase())
+                .mediaType(mediaType) //.mediaType(item.getMediaType().toString().toLowerCase())
                 .score(item.getScore())
                 .content(item.getContent())
                 .build();
@@ -78,7 +82,7 @@ public class RecommendService {
     private ItemRecommendRequest itemRecommendRequest(Creator creator) {
         return ItemRecommendRequest.builder()
                 .nickname(creator.getNickname())
-                .category(creator.getCategory().toString())
+                .category(creator.getCategory().toString().toLowerCase())
                 .subscribers(creator.getSubscribers())
                 .build();
     }

--- a/src/main/java/com/ktb/joing/domain/recommend/service/RecommendService.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/service/RecommendService.java
@@ -1,0 +1,86 @@
+package com.ktb.joing.domain.recommend.service;
+
+import com.ktb.joing.domain.item.entity.Item;
+import com.ktb.joing.domain.item.exception.ItemErrorCode;
+import com.ktb.joing.domain.item.exception.ItemException;
+import com.ktb.joing.domain.item.repository.ItemRepository;
+import com.ktb.joing.domain.recommend.client.RecommendAIClient;
+import com.ktb.joing.domain.recommend.dto.request.CreatorRecommendRequest;
+import com.ktb.joing.domain.recommend.dto.request.ItemRecommendRequest;
+import com.ktb.joing.domain.recommend.dto.response.CreatorRecommendResponse;
+import com.ktb.joing.domain.recommend.dto.response.ItemRecommendResponse;
+import com.ktb.joing.domain.recommend.exception.RecommendErrorCode;
+import com.ktb.joing.domain.recommend.exception.RecommendException;
+import com.ktb.joing.domain.user.entity.Creator;
+import com.ktb.joing.domain.user.exception.UserErrorCode;
+import com.ktb.joing.domain.user.exception.UserException;
+import com.ktb.joing.domain.user.repository.CreatorRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class RecommendService {
+    private final RecommendAIClient recommendAIClient;
+    private final ItemRepository itemRepository;
+    private final CreatorRepository creatorRepository;
+
+    // 기획안를 가지고 -> 크리에이터 추천
+    public Mono<CreatorRecommendResponse> getRecommendedCreators(Long itemId, String username){
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new ItemException(ItemErrorCode.ITEM_NOT_FOUND));
+
+        // 권한 체크
+        if (!item.getProductManager().getUsername().equals(username)) {
+            throw new ItemException(ItemErrorCode.ITEM_NOT_AUTHORIZED);
+        }
+
+        // AI 추천 요청 생성
+        CreatorRecommendRequest request = creatorRecommendRequest(item);
+
+        return recommendAIClient.requestCreatorRecommend(request)
+                .onErrorMap(e -> new RecommendException(RecommendErrorCode.AI_RECOMMEND_FAILED));
+
+    }
+
+    // 크리에이터 가지고 -> 기획안 추천
+    public Mono<ItemRecommendResponse> getRecommendedItems(Long userId, String username){
+        Creator creator = creatorRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        // AI 추천 요청 생성
+        ItemRecommendRequest request = itemRecommendRequest(creator);
+
+        // 권한 체크
+        if(!creator.getUsername().equals(username)){
+            throw new UserException(UserErrorCode.USER_NOT_AUTHORIZED);
+        }
+
+        return recommendAIClient.requestItemRecommend(request)
+                .onErrorMap(e -> new RecommendException(RecommendErrorCode.AI_RECOMMEND_FAILED));
+    }
+
+    private CreatorRecommendRequest creatorRecommendRequest(Item item) {
+        return CreatorRecommendRequest.builder()
+                .title(item.getTitle())
+                .category(item.getCategory().toString().toLowerCase())
+                .mediaType(item.getMediaType().toString().toLowerCase())
+                .score(item.getScore())
+                .content(item.getContent())
+                .build();
+    }
+
+    private ItemRecommendRequest itemRecommendRequest(Creator creator) {
+        return ItemRecommendRequest.builder()
+                .nickname(creator.getNickname())
+                .category(creator.getCategory().toString())
+                .subscribers(creator.getSubscribers())
+                .build();
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/recommend/service/RecommendService.java
+++ b/src/main/java/com/ktb/joing/domain/recommend/service/RecommendService.java
@@ -12,7 +12,6 @@ import com.ktb.joing.domain.recommend.dto.response.ItemRecommendResponse;
 import com.ktb.joing.domain.recommend.exception.RecommendErrorCode;
 import com.ktb.joing.domain.recommend.exception.RecommendException;
 import com.ktb.joing.domain.user.entity.Creator;
-import com.ktb.joing.domain.user.entity.MediaType;
 import com.ktb.joing.domain.user.exception.UserErrorCode;
 import com.ktb.joing.domain.user.exception.UserException;
 import com.ktb.joing.domain.user.repository.CreatorRepository;
@@ -67,13 +66,10 @@ public class RecommendService {
     }
 
     private CreatorRecommendRequest creatorRecommendRequest(Item item) {
-        String mediaType = null;
-        if (item.getMediaType()==MediaType.LONG_FORM) mediaType = "long";
-        else if (item.getMediaType()==MediaType.SHORT_FORM) mediaType = "short";
         return CreatorRecommendRequest.builder()
                 .title(item.getTitle())
                 .category(item.getCategory().toString().toLowerCase())
-                .mediaType(mediaType) //.mediaType(item.getMediaType().toString().toLowerCase())
+                .mediaType(item.getMediaType().toString().toLowerCase())
                 .score(item.getScore())
                 .content(item.getContent())
                 .build();

--- a/src/main/java/com/ktb/joing/domain/user/dto/request/CreatorSignupRequest.java
+++ b/src/main/java/com/ktb/joing/domain/user/dto/request/CreatorSignupRequest.java
@@ -17,7 +17,7 @@ public class CreatorSignupRequest {
     private String nickname;
 
     @NotBlank
-    @Email(regexp = "^[A-Za-z0-9+_.-]+@(.+)$", message = "올바른 이메일 형식이 아닙니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
     private String email;
 
     private String channelId;

--- a/src/main/java/com/ktb/joing/domain/user/dto/request/ProfileEvaluationRequest.java
+++ b/src/main/java/com/ktb/joing/domain/user/dto/request/ProfileEvaluationRequest.java
@@ -1,6 +1,5 @@
 package com.ktb.joing.domain.user.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +7,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProfileEvaluationRequest {
-    @JsonProperty("channel_id")
     private String channelId;
 
     public ProfileEvaluationRequest(String channelId) {

--- a/src/main/java/com/ktb/joing/domain/user/dto/response/ProfileEvaluationResponse.java
+++ b/src/main/java/com/ktb/joing/domain/user/dto/response/ProfileEvaluationResponse.java
@@ -8,12 +8,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProfileEvaluationResponse {
-    private boolean appropriate;
+    private boolean evaluation_status;
     private String reason;
 
     @Builder
-    public ProfileEvaluationResponse(boolean appropriate, String reason) {
-        this.appropriate = appropriate;
+    public ProfileEvaluationResponse(boolean evaluation_status, String reason) {
+        this.evaluation_status = evaluation_status;
         this.reason = reason;
     }
 }

--- a/src/main/java/com/ktb/joing/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/ktb/joing/domain/user/exception/UserErrorCode.java
@@ -12,6 +12,7 @@ public enum UserErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저가 존재하지 않습니다"),
     TEMP_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "임시 저장된 사용자 정보가 없습니다."),
     DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다"),
+    USER_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "해당 유저에 대한 권한이 없습니다."),
     PROFILE_EVALUATION_FAILED(HttpStatus.BAD_GATEWAY, "AI 프로필 평가 요청에 실패했습니다");
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #JOING-58

<br/>

## 📝 작업 내용

> AI 기반으로 추천해주는 기능을 구현하였습니다.
> 기획안(item)정보를 통해 크리에이터를 추천받고, 크리에이터(creator)정보를 통해 기획안을 추천 받도록 하였습니다.
> AI와의 통신은 WebClient를 이용하여 구현하였고 현재는 아직 비동기가 정상적으로 작동하지 않습니다. 추후 메시지 큐를 도입하여 비동기 처리를 개선할 예정입니다.

<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 
