### PR TITLE
JOING-48 feat: 매칭 기능 API 구현 및 알림 기능 구현

### DIFF
--- a/src/main/java/com/ktb/joing/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/ktb/joing/domain/matching/controller/MatchingController.java
@@ -5,6 +5,7 @@ import com.ktb.joing.domain.matching.dto.request.MatchingRequestToCreator;
 import com.ktb.joing.domain.matching.dto.request.MatchingRequestToItem;
 import com.ktb.joing.domain.matching.dto.request.MatchingStatusRequest;
 import com.ktb.joing.domain.matching.dto.response.MatchingDetailResponse;
+import com.ktb.joing.domain.matching.dto.response.MatchingListResponse;
 import com.ktb.joing.domain.matching.dto.response.MatchingResponse;
 import com.ktb.joing.domain.matching.service.MatchingService;
 import jakarta.validation.Valid;
@@ -21,6 +22,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @Slf4j
@@ -43,6 +46,12 @@ public class MatchingController {
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(matchingService.createMatchingToItem(request, customOAuth2User.getUsername()));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MatchingListResponse>> getMatchingList(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(matchingService.getMatchingList(customOAuth2User.getUsername()));
     }
 
     @GetMapping("/{matchingId}")

--- a/src/main/java/com/ktb/joing/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/ktb/joing/domain/matching/controller/MatchingController.java
@@ -1,0 +1,65 @@
+package com.ktb.joing.domain.matching.controller;
+
+import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
+import com.ktb.joing.domain.matching.dto.request.MatchingStatusRequest;
+import com.ktb.joing.domain.matching.dto.response.MatchingResponse;
+import com.ktb.joing.domain.matching.service.MatchingService;
+import com.ktb.joing.domain.matching.dto.request.MatchingRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/matching")
+public class MatchingController {
+    private final MatchingService matchingService;
+
+    @PostMapping
+    public ResponseEntity<MatchingResponse> requestMatching(
+            @RequestBody @Valid MatchingRequest request,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(
+                matchingService.createMatching(request, customOAuth2User.getUsername())
+        );
+    }
+
+    @GetMapping("/{matchingId}")
+    public ResponseEntity<MatchingResponse> getMatchingStatus(
+            @PathVariable Long matchingId,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(
+                matchingService.getMatchingStatus(matchingId, customOAuth2User.getUsername())
+        );
+    }
+
+    @DeleteMapping("/{matchingId}")
+    public ResponseEntity<Void> cancelMatching(
+            @PathVariable Long matchingId,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        matchingService.cancelMatching(matchingId, customOAuth2User.getUsername());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{matchingId}/status")
+    public ResponseEntity<MatchingResponse> updateMatchingStatus(
+            @PathVariable Long matchingId,
+            @RequestBody @Valid MatchingStatusRequest request,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(
+                matchingService.updateMatchingStatus(matchingId, request.getStatus(), customOAuth2User.getUsername())
+        );
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/ktb/joing/domain/matching/controller/MatchingController.java
@@ -4,6 +4,7 @@ import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
 import com.ktb.joing.domain.matching.dto.request.MatchingRequestToCreator;
 import com.ktb.joing.domain.matching.dto.request.MatchingRequestToItem;
 import com.ktb.joing.domain.matching.dto.request.MatchingStatusRequest;
+import com.ktb.joing.domain.matching.dto.response.MatchingDetailResponse;
 import com.ktb.joing.domain.matching.dto.response.MatchingResponse;
 import com.ktb.joing.domain.matching.service.MatchingService;
 import jakarta.validation.Valid;
@@ -45,6 +46,13 @@ public class MatchingController {
     }
 
     @GetMapping("/{matchingId}")
+    public ResponseEntity<MatchingDetailResponse> getMatching(
+            @PathVariable Long matchingId,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(matchingService.getMatching(matchingId, customOAuth2User.getUsername()));
+    }
+
+    @GetMapping("/{matchingId}/status")
     public ResponseEntity<MatchingResponse> getMatchingStatus(
             @PathVariable Long matchingId,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {

--- a/src/main/java/com/ktb/joing/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/ktb/joing/domain/matching/controller/MatchingController.java
@@ -1,13 +1,15 @@
 package com.ktb.joing.domain.matching.controller;
 
 import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
+import com.ktb.joing.domain.matching.dto.request.MatchingRequestToCreator;
+import com.ktb.joing.domain.matching.dto.request.MatchingRequestToItem;
 import com.ktb.joing.domain.matching.dto.request.MatchingStatusRequest;
 import com.ktb.joing.domain.matching.dto.response.MatchingResponse;
 import com.ktb.joing.domain.matching.service.MatchingService;
-import com.ktb.joing.domain.matching.dto.request.MatchingRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -26,13 +28,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class MatchingController {
     private final MatchingService matchingService;
 
-    @PostMapping
-    public ResponseEntity<MatchingResponse> requestMatching(
-            @RequestBody @Valid MatchingRequest request,
+    @PostMapping("/creator")
+    public ResponseEntity<MatchingResponse> requestMatchingToCreator(
+            @RequestBody @Valid MatchingRequestToCreator request,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-        return ResponseEntity.ok(
-                matchingService.createMatching(request, customOAuth2User.getUsername())
-        );
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(matchingService.createMatchingToCreator(request, customOAuth2User.getUsername()));
+    }
+
+    @PostMapping("/item")
+    public ResponseEntity<MatchingResponse> requestMatchingToItem(
+            @RequestBody @Valid MatchingRequestToItem request,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(matchingService.createMatchingToItem(request, customOAuth2User.getUsername()));
     }
 
     @GetMapping("/{matchingId}")

--- a/src/main/java/com/ktb/joing/domain/matching/dto/request/MatchingRequest.java
+++ b/src/main/java/com/ktb/joing/domain/matching/dto/request/MatchingRequest.java
@@ -1,0 +1,18 @@
+package com.ktb.joing.domain.matching.dto.request;
+
+import com.ktb.joing.domain.matching.entity.MatchingSender;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingRequest {
+    @NotNull
+    private Long itemId;
+    @NotNull
+    private Long creatorId;
+    @NotNull
+    private MatchingSender sender;
+}

--- a/src/main/java/com/ktb/joing/domain/matching/dto/request/MatchingRequestToCreator.java
+++ b/src/main/java/com/ktb/joing/domain/matching/dto/request/MatchingRequestToCreator.java
@@ -1,0 +1,15 @@
+package com.ktb.joing.domain.matching.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingRequestToCreator {
+    @NotNull
+    private Long itemId;
+    @NotNull
+    private Long creatorId;
+}

--- a/src/main/java/com/ktb/joing/domain/matching/dto/request/MatchingRequestToItem.java
+++ b/src/main/java/com/ktb/joing/domain/matching/dto/request/MatchingRequestToItem.java
@@ -1,6 +1,5 @@
 package com.ktb.joing.domain.matching.dto.request;
 
-import com.ktb.joing.domain.matching.entity.MatchingSender;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -8,11 +7,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MatchingRequest {
+public class MatchingRequestToItem {
     @NotNull
     private Long itemId;
-    @NotNull
-    private Long creatorId;
-    @NotNull
-    private MatchingSender sender;
 }

--- a/src/main/java/com/ktb/joing/domain/matching/dto/request/MatchingStatusRequest.java
+++ b/src/main/java/com/ktb/joing/domain/matching/dto/request/MatchingStatusRequest.java
@@ -1,0 +1,18 @@
+package com.ktb.joing.domain.matching.dto.request;
+
+import com.ktb.joing.domain.matching.entity.MatchingStatus;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingStatusRequest {
+    private MatchingStatus status;
+
+    @Builder
+    public MatchingStatusRequest(MatchingStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/matching/dto/response/MatchingDetailResponse.java
+++ b/src/main/java/com/ktb/joing/domain/matching/dto/response/MatchingDetailResponse.java
@@ -1,0 +1,47 @@
+package com.ktb.joing.domain.matching.dto.response;
+
+import com.ktb.joing.domain.matching.entity.Matching;
+import com.ktb.joing.domain.matching.entity.MatchingSender;
+import com.ktb.joing.domain.matching.entity.MatchingStatus;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingDetailResponse {
+    private String productManagerNickname;
+    private String productManagerEmail;
+    private Long itemId;
+    private String itemTitle;
+    private String itemContent;
+    private String itemKeyword;
+
+    private String creatorNickname;
+    private String creatorProfileImage;
+    private String creatorEmail;
+    private String creatorChannelUrl;
+
+    private MatchingStatus status;
+    private MatchingSender sender;
+
+    @Builder
+    public MatchingDetailResponse(Matching matching){
+        this.productManagerNickname = matching.getItem().getProductManager().getNickname();
+        this.productManagerEmail = matching.getItem().getProductManager().getEmail();
+
+        this.itemId = matching.getItem().getId();
+        this.itemTitle = matching.getItem().getTitle();
+        this.itemContent = matching.getItem().getContent();
+        this.itemKeyword = matching.getItem().getSummary().getKeyword();
+
+        this.creatorNickname = matching.getCreator().getNickname();
+        this.creatorProfileImage = matching.getCreator().getProfileImage();
+        this.creatorEmail = matching.getCreator().getEmail();
+        this.creatorChannelUrl = matching.getCreator().getChannelUrl();
+
+        this.status = matching.getStatus();
+        this.sender = matching.getSender();
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/matching/dto/response/MatchingListResponse.java
+++ b/src/main/java/com/ktb/joing/domain/matching/dto/response/MatchingListResponse.java
@@ -1,0 +1,22 @@
+package com.ktb.joing.domain.matching.dto.response;
+
+import com.ktb.joing.domain.matching.entity.MatchingStatus;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingListResponse {
+    private Long matchingId;
+    private String title;
+    private MatchingStatus status;
+
+    @Builder
+    public MatchingListResponse(Long matchingId, String title, MatchingStatus status) {
+        this.matchingId = matchingId;
+        this.title = title;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/matching/dto/response/MatchingResponse.java
+++ b/src/main/java/com/ktb/joing/domain/matching/dto/response/MatchingResponse.java
@@ -1,0 +1,28 @@
+package com.ktb.joing.domain.matching.dto.response;
+
+import com.ktb.joing.domain.matching.entity.MatchingSender;
+import com.ktb.joing.domain.matching.entity.MatchingStatus;
+import com.ktb.joing.domain.matching.entity.Matching;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingResponse {
+    private Long matchingId;
+    private Long itemId;
+    private Long creatorId;
+    private MatchingStatus status;
+    private MatchingSender sender;
+
+    @Builder
+    public MatchingResponse(Matching matching) {
+        this.matchingId = matching.getId();
+        this.itemId = matching.getItem().getId();
+        this.creatorId = matching.getCreator().getId();
+        this.status = matching.getStatus();
+        this.sender = matching.getSender();
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/matching/entity/Matching.java
+++ b/src/main/java/com/ktb/joing/domain/matching/entity/Matching.java
@@ -1,0 +1,62 @@
+package com.ktb.joing.domain.matching.entity;
+
+import com.ktb.joing.common.model.BaseTimeEntity;
+import com.ktb.joing.domain.item.entity.Item;
+import com.ktb.joing.domain.user.entity.Creator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Matching extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "matching_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Item item;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Creator creator;
+
+    @Enumerated(EnumType.STRING)
+    private MatchingStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private MatchingSender sender;
+
+    @Builder
+    public Matching(Item item, Creator creator, MatchingSender sender) {
+        this.item = item;
+        this.creator = creator;
+        this.status = MatchingStatus.PENDING;
+        this.sender = sender;
+    }
+
+    public void updateStatus(MatchingStatus status) {
+        this.status = status;
+    }
+
+    public void cancel() {
+        this.status = MatchingStatus.CANCELED;
+    }
+
+    public boolean isReceiver(String username) {
+        return sender == MatchingSender.PRODUCT_MANAGER ?
+                creator.getUsername().equals(username) :
+                item.getProductManager().getUsername().equals(username);
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/matching/entity/MatchingSender.java
+++ b/src/main/java/com/ktb/joing/domain/matching/entity/MatchingSender.java
@@ -1,0 +1,5 @@
+package com.ktb.joing.domain.matching.entity;
+
+public enum MatchingSender {
+    PRODUCT_MANAGER, CREATOR
+}

--- a/src/main/java/com/ktb/joing/domain/matching/entity/MatchingStatus.java
+++ b/src/main/java/com/ktb/joing/domain/matching/entity/MatchingStatus.java
@@ -1,0 +1,8 @@
+package com.ktb.joing.domain.matching.entity;
+
+public enum MatchingStatus {
+    PENDING,    // 대기 중(요청했을때)
+    ACCEPTED,   // 수락됨
+    REJECTED,   // 거절됨
+    CANCELED   // 취소됨
+}

--- a/src/main/java/com/ktb/joing/domain/matching/exception/MatchingErrorCode.java
+++ b/src/main/java/com/ktb/joing/domain/matching/exception/MatchingErrorCode.java
@@ -1,0 +1,34 @@
+package com.ktb.joing.domain.matching.exception;
+
+import com.ktb.joing.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MatchingErrorCode implements ErrorCode {
+    // Matching Error
+    // 매칭을 찾을 수 없는 경우
+    MATCHING_NOT_FOUND(HttpStatus.NOT_FOUND, "매칭 정보를 찾을 수 없습니다."),
+
+    // 권한 관련 에러
+    MATCHING_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "매칭에 대한 권한이 없습니다."),
+    MATCHING_REQUEST_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "매칭 요청에 대한 권한이 없습니다."),
+
+    // 매칭 상태 관련 에러
+    INVALID_MATCHING_STATUS(HttpStatus.BAD_REQUEST, "잘못된 매칭 상태입니다."),
+    MATCHING_STATUS_TRANSITION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "해당 상태로 변경할 수 없습니다."),
+    MATCHING_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 매칭입니다."),
+
+    // 매칭 생성 관련 에러
+    INVALID_MATCHING_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 매칭 요청입니다."),
+    MATCHING_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 매칭입니다."),
+
+    // 매칭 취소 관련 에러
+    MATCHING_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "취소할 수 없는 매칭 상태입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/ktb/joing/domain/matching/exception/MatchingException.java
+++ b/src/main/java/com/ktb/joing/domain/matching/exception/MatchingException.java
@@ -1,0 +1,14 @@
+package com.ktb.joing.domain.matching.exception;
+
+import com.ktb.joing.common.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class MatchingException extends BusinessException {
+    private final MatchingErrorCode matchingErrorCode;
+
+    public MatchingException(MatchingErrorCode matchingErrorCode) {
+        super(matchingErrorCode);
+        this.matchingErrorCode = matchingErrorCode;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/com/ktb/joing/domain/matching/repository/MatchingRepository.java
@@ -1,0 +1,7 @@
+package com.ktb.joing.domain.matching.repository;
+
+import com.ktb.joing.domain.matching.entity.Matching;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchingRepository extends JpaRepository<Matching, Long> {
+}

--- a/src/main/java/com/ktb/joing/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/com/ktb/joing/domain/matching/repository/MatchingRepository.java
@@ -2,6 +2,16 @@ package com.ktb.joing.domain.matching.repository;
 
 import com.ktb.joing.domain.matching.entity.Matching;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
+    @Query("SELECT m FROM Matching m " +
+            "WHERE (m.creator.username = :username OR m.item.productManager.username = :username) " +
+            "AND m.status NOT IN (:#{T(com.ktb.joing.domain.matching.entity.MatchingStatus).CANCELED}, " +
+            ":#{T(com.ktb.joing.domain.matching.entity.MatchingStatus).REJECTED})")
+    List<Matching> findActiveMatchingsByUsername(@Param("username") String username);
+
 }

--- a/src/main/java/com/ktb/joing/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/ktb/joing/domain/matching/service/MatchingService.java
@@ -1,0 +1,126 @@
+package com.ktb.joing.domain.matching.service;
+
+import com.ktb.joing.domain.item.entity.Item;
+import com.ktb.joing.domain.item.exception.ItemErrorCode;
+import com.ktb.joing.domain.item.exception.ItemException;
+import com.ktb.joing.domain.item.repository.ItemRepository;
+import com.ktb.joing.domain.matching.entity.MatchingSender;
+import com.ktb.joing.domain.matching.entity.MatchingStatus;
+import com.ktb.joing.domain.matching.dto.request.MatchingRequest;
+import com.ktb.joing.domain.matching.dto.response.MatchingResponse;
+import com.ktb.joing.domain.matching.entity.Matching;
+import com.ktb.joing.domain.matching.exception.MatchingErrorCode;
+import com.ktb.joing.domain.matching.exception.MatchingException;
+import com.ktb.joing.domain.matching.repository.MatchingRepository;
+import com.ktb.joing.domain.user.entity.Creator;
+import com.ktb.joing.domain.user.exception.UserErrorCode;
+import com.ktb.joing.domain.user.exception.UserException;
+import com.ktb.joing.domain.user.repository.CreatorRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MatchingService {
+
+    private final MatchingRepository matchingRepository;
+    private final ItemRepository itemRepository;
+    private final CreatorRepository creatorRepository;
+
+    // 매칭 요청 생성
+    public MatchingResponse createMatching(MatchingRequest request, String username) {
+
+        Item item = itemRepository.findById(request.getItemId())
+                .orElseThrow(() -> new ItemException(ItemErrorCode.ITEM_NOT_FOUND));
+        Creator creator = creatorRepository.findById(request.getCreatorId())
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        //권한 검증 - 요청을 보내는 사람이 실제로 기획안 작성인/크리에이터 본인이 맞는지 확인
+        if (request.getSender() == MatchingSender.PRODUCT_MANAGER) {
+            if (!item.getProductManager().getUsername().equals(username)) {
+                throw new MatchingException(MatchingErrorCode.MATCHING_NOT_AUTHORIZED);
+            }
+        }else{
+            if (!creator.getUsername().equals(username)) {
+                throw new MatchingException(MatchingErrorCode.MATCHING_NOT_AUTHORIZED);
+            }
+        }
+
+        Matching matching = Matching.builder()
+                .item(item)
+                .creator(creator)
+                .sender(request.getSender())
+                .build();
+
+        matching = matchingRepository.save(matching);
+        return new MatchingResponse(matching);
+    }
+
+    // 매칭 상태 조회
+    public MatchingResponse getMatchingStatus(Long matchingId, String username) {
+        Matching matching = matchingRepository.findById(matchingId)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCHING_NOT_FOUND));
+
+        // 권한 검증 - 매칭 참여자만 조회 가능
+        if (!matching.getCreator().getUsername().equals(username) &&
+                !matching.getItem().getProductManager().getUsername().equals(username)) {
+            throw new MatchingException(MatchingErrorCode.MATCHING_NOT_AUTHORIZED);
+        }
+
+        return new MatchingResponse(matching);
+    }
+
+    // 매칭 취소
+    public void cancelMatching(Long matchingId, String username) {
+        Matching matching = matchingRepository.findById(matchingId)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCHING_NOT_FOUND));
+        log.info("매칭 id로 매칭 찾기 {}", matching.toString());
+
+        // 권한 검증 - 매칭을 요청한 사람만 취소 가능
+        if (matching.getSender() == MatchingSender.PRODUCT_MANAGER) {
+            if (!matching.getItem().getProductManager().getUsername().equals(username)) {
+                log.info("요청한 사람이 기획자");
+                throw new MatchingException(MatchingErrorCode.MATCHING_NOT_AUTHORIZED);
+            }
+        } else {
+            if (!matching.getCreator().getUsername().equals(username)) {
+                throw new MatchingException(MatchingErrorCode.MATCHING_NOT_AUTHORIZED);
+            }
+        }
+
+        if (matching.getStatus() != MatchingStatus.PENDING) {
+            throw new MatchingException(MatchingErrorCode.INVALID_MATCHING_STATUS);
+        }
+
+        matching.cancel();
+        matchingRepository.save(matching);
+    }
+
+    // 매칭 답장에 대한 응답 - 매칭 상태 변경 (수락/ 거절)
+    public MatchingResponse updateMatchingStatus(Long matchingId, MatchingStatus newStatus, String username) {
+        Matching matching = matchingRepository.findById(matchingId)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCHING_NOT_FOUND));
+
+        // 권한 검증 - 매칭 요청을 받은 사람만 응답 가능
+        if (!matching.isReceiver(username)) {
+            throw new MatchingException(MatchingErrorCode.MATCHING_NOT_AUTHORIZED);
+        }
+
+        if (matching.getStatus() != MatchingStatus.PENDING) {
+            throw new MatchingException(MatchingErrorCode.MATCHING_CANCEL_NOT_ALLOWED);
+        }
+
+        if (newStatus != MatchingStatus.ACCEPTED && newStatus != MatchingStatus.REJECTED) {
+            throw new MatchingException(MatchingErrorCode.INVALID_MATCHING_STATUS);
+        }
+
+        matching.updateStatus(newStatus);
+        matching = matchingRepository.save(matching);
+        return new MatchingResponse(matching);
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/ktb/joing/domain/matching/service/MatchingService.java
@@ -12,7 +12,9 @@ import com.ktb.joing.domain.matching.entity.Matching;
 import com.ktb.joing.domain.matching.exception.MatchingErrorCode;
 import com.ktb.joing.domain.matching.exception.MatchingException;
 import com.ktb.joing.domain.matching.repository.MatchingRepository;
+import com.ktb.joing.domain.notification.service.NotificationService;
 import com.ktb.joing.domain.user.entity.Creator;
+import com.ktb.joing.domain.user.entity.User;
 import com.ktb.joing.domain.user.exception.UserErrorCode;
 import com.ktb.joing.domain.user.exception.UserException;
 import com.ktb.joing.domain.user.repository.CreatorRepository;
@@ -30,6 +32,7 @@ public class MatchingService {
     private final MatchingRepository matchingRepository;
     private final ItemRepository itemRepository;
     private final CreatorRepository creatorRepository;
+    private final NotificationService notificationService;
 
     // 매칭 요청 생성
     public MatchingResponse createMatching(MatchingRequest request, String username) {
@@ -57,6 +60,9 @@ public class MatchingService {
                 .build();
 
         matching = matchingRepository.save(matching);
+
+        sendMatchingNotification(matching, MatchingStatus.PENDING);
+
         return new MatchingResponse(matching);
     }
 
@@ -98,6 +104,8 @@ public class MatchingService {
 
         matching.cancel();
         matchingRepository.save(matching);
+
+        sendMatchingNotification(matching, MatchingStatus.CANCELED);
     }
 
     // 매칭 답장에 대한 응답 - 매칭 상태 변경 (수락/ 거절)
@@ -120,7 +128,63 @@ public class MatchingService {
 
         matching.updateStatus(newStatus);
         matching = matchingRepository.save(matching);
+
+        sendMatchingNotification(matching, newStatus);
+
         return new MatchingResponse(matching);
     }
 
+    private void sendMatchingNotification(Matching matching, MatchingStatus action) {
+        String notificationContent;
+        String relatedUrl = "/matching/" + matching.getId();
+        User receiver;
+        boolean isProductManagerSender = matching.getSender() == MatchingSender.PRODUCT_MANAGER;
+
+        switch(action) {
+            case PENDING:
+                if (isProductManagerSender) {
+                    notificationContent = String.format("[매칭 요청] %s님이 '%s' 기획안에 대해 매칭을 요청했습니다.",
+                            matching.getItem().getProductManager().getNickname(),
+                            matching.getItem().getTitle());
+                    receiver = matching.getCreator();
+                } else {
+                    notificationContent = String.format("[매칭 요청] %s님이 '%s' 기획안에 참여하고 싶어합니다.",
+                            matching.getCreator().getNickname(),
+                            matching.getItem().getTitle());
+                    receiver = matching.getItem().getProductManager();
+                }
+                break;
+
+            case CANCELED:
+                if (isProductManagerSender) {
+                    notificationContent = String.format("[매칭 취소] '%s' 기획안에 대한 매칭 요청이 취소되었습니다.",
+                            matching.getItem().getTitle());
+                    receiver = matching.getCreator();
+                } else {
+                    notificationContent = String.format("[매칭 취소] '%s' 기획안에 대한 참여 요청이 취소되었습니다.",
+                            matching.getItem().getTitle());
+                    receiver = matching.getItem().getProductManager();
+                }
+                break;
+
+            case ACCEPTED:
+            case REJECTED:
+                String actionStr = action.toString().toLowerCase();
+                if (isProductManagerSender) {
+                    notificationContent = String.format("[매칭 %s] '%s' 기획안에 대한 매칭 요청이 %s되었습니다.",
+                            actionStr, matching.getItem().getTitle(), actionStr);
+                    receiver = matching.getItem().getProductManager();
+                } else {
+                    notificationContent = String.format("[매칭 %s] '%s' 기획안에 대한 참여 요청이 %s되었습니다.",
+                            actionStr, matching.getItem().getTitle(), actionStr);
+                    receiver = matching.getCreator();
+                }
+                break;
+
+            default:
+                throw new MatchingException(MatchingErrorCode.INVALID_MATCHING_STATUS);
+        }
+
+        notificationService.send(receiver, notificationContent, relatedUrl);
+    }
 }

--- a/src/main/java/com/ktb/joing/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/ktb/joing/domain/matching/service/MatchingService.java
@@ -6,6 +6,7 @@ import com.ktb.joing.domain.item.exception.ItemException;
 import com.ktb.joing.domain.item.repository.ItemRepository;
 import com.ktb.joing.domain.matching.dto.request.MatchingRequestToCreator;
 import com.ktb.joing.domain.matching.dto.request.MatchingRequestToItem;
+import com.ktb.joing.domain.matching.dto.response.MatchingDetailResponse;
 import com.ktb.joing.domain.matching.entity.MatchingSender;
 import com.ktb.joing.domain.matching.entity.MatchingStatus;
 import com.ktb.joing.domain.matching.dto.response.MatchingResponse;
@@ -79,6 +80,23 @@ public class MatchingService {
         return new MatchingResponse(matching);
     }
 
+    // 매칭 자세한 내용 - 매칭 수락시 화면
+    public MatchingDetailResponse getMatching(Long matchingId, String username) {
+        // 매칭 정보 조회
+        Matching matching = matchingRepository.findById(matchingId)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCHING_NOT_FOUND));
+
+        // 접근 권한 확인 - 매칭의 크리에이터이거나 기획자만 조회 가능
+        if (!matching.getCreator().getUsername().equals(username) &&
+                !matching.getItem().getProductManager().getUsername().equals(username)) {
+            throw new MatchingException(MatchingErrorCode.MATCHING_NOT_AUTHORIZED);
+        }
+
+        return MatchingDetailResponse.builder()
+                .matching(matching)
+                .build();
+    }
+
     // 매칭 상태 조회
     public MatchingResponse getMatchingStatus(Long matchingId, String username) {
         Matching matching = matchingRepository.findById(matchingId)
@@ -90,19 +108,19 @@ public class MatchingService {
             throw new MatchingException(MatchingErrorCode.MATCHING_NOT_AUTHORIZED);
         }
 
-        return new MatchingResponse(matching);
+        return MatchingResponse.builder()
+                .matching(matching)
+                .build();
     }
 
     // 매칭 취소
     public void cancelMatching(Long matchingId, String username) {
         Matching matching = matchingRepository.findById(matchingId)
                 .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCHING_NOT_FOUND));
-        log.info("매칭 id로 매칭 찾기 {}", matching.toString());
 
         // 권한 검증 - 매칭을 요청한 사람만 취소 가능
         if (matching.getSender() == MatchingSender.PRODUCT_MANAGER) {
             if (!matching.getItem().getProductManager().getUsername().equals(username)) {
-                log.info("요청한 사람이 기획자");
                 throw new MatchingException(MatchingErrorCode.MATCHING_NOT_AUTHORIZED);
             }
         } else {

--- a/src/main/java/com/ktb/joing/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/ktb/joing/domain/matching/service/MatchingService.java
@@ -4,9 +4,10 @@ import com.ktb.joing.domain.item.entity.Item;
 import com.ktb.joing.domain.item.exception.ItemErrorCode;
 import com.ktb.joing.domain.item.exception.ItemException;
 import com.ktb.joing.domain.item.repository.ItemRepository;
+import com.ktb.joing.domain.matching.dto.request.MatchingRequestToCreator;
+import com.ktb.joing.domain.matching.dto.request.MatchingRequestToItem;
 import com.ktb.joing.domain.matching.entity.MatchingSender;
 import com.ktb.joing.domain.matching.entity.MatchingStatus;
-import com.ktb.joing.domain.matching.dto.request.MatchingRequest;
 import com.ktb.joing.domain.matching.dto.response.MatchingResponse;
 import com.ktb.joing.domain.matching.entity.Matching;
 import com.ktb.joing.domain.matching.exception.MatchingErrorCode;
@@ -34,33 +35,45 @@ public class MatchingService {
     private final CreatorRepository creatorRepository;
     private final NotificationService notificationService;
 
-    // 매칭 요청 생성
-    public MatchingResponse createMatching(MatchingRequest request, String username) {
-
+    // 기획자가 크리에이터에게 매칭 요청
+    public MatchingResponse createMatchingToCreator(MatchingRequestToCreator request, String username) {
         Item item = itemRepository.findById(request.getItemId())
                 .orElseThrow(() -> new ItemException(ItemErrorCode.ITEM_NOT_FOUND));
         Creator creator = creatorRepository.findById(request.getCreatorId())
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        //권한 검증 - 요청을 보내는 사람이 실제로 기획안 작성인/크리에이터 본인이 맞는지 확인
-        if (request.getSender() == MatchingSender.PRODUCT_MANAGER) {
-            if (!item.getProductManager().getUsername().equals(username)) {
-                throw new MatchingException(MatchingErrorCode.MATCHING_NOT_AUTHORIZED);
-            }
-        }else{
-            if (!creator.getUsername().equals(username)) {
-                throw new MatchingException(MatchingErrorCode.MATCHING_NOT_AUTHORIZED);
-            }
+        // 권한 검증 - 요청자가 해당 아이템의 기획자인지 확인
+        if (!item.getProductManager().getUsername().equals(username)) {
+            throw new MatchingException(MatchingErrorCode.MATCHING_NOT_AUTHORIZED);
         }
 
         Matching matching = Matching.builder()
                 .item(item)
                 .creator(creator)
-                .sender(request.getSender())
+                .sender(MatchingSender.PRODUCT_MANAGER)
                 .build();
 
         matching = matchingRepository.save(matching);
+        sendMatchingNotification(matching, MatchingStatus.PENDING);
 
+        return new MatchingResponse(matching);
+    }
+
+    // 크리에이터가 기획자(기획안)에게 매칭 요청
+    public MatchingResponse createMatchingToItem(MatchingRequestToItem request, String username) {
+        Item item = itemRepository.findById(request.getItemId())
+                .orElseThrow(() -> new ItemException(ItemErrorCode.ITEM_NOT_FOUND));
+
+        Creator creator = creatorRepository.findByUsername(username)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        Matching matching = Matching.builder()
+                .item(item)
+                .creator(creator)
+                .sender(MatchingSender.CREATOR)
+                .build();
+
+        matching = matchingRepository.save(matching);
         sendMatchingNotification(matching, MatchingStatus.PENDING);
 
         return new MatchingResponse(matching);

--- a/src/main/java/com/ktb/joing/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/ktb/joing/domain/matching/service/MatchingService.java
@@ -7,6 +7,7 @@ import com.ktb.joing.domain.item.repository.ItemRepository;
 import com.ktb.joing.domain.matching.dto.request.MatchingRequestToCreator;
 import com.ktb.joing.domain.matching.dto.request.MatchingRequestToItem;
 import com.ktb.joing.domain.matching.dto.response.MatchingDetailResponse;
+import com.ktb.joing.domain.matching.dto.response.MatchingListResponse;
 import com.ktb.joing.domain.matching.entity.MatchingSender;
 import com.ktb.joing.domain.matching.entity.MatchingStatus;
 import com.ktb.joing.domain.matching.dto.response.MatchingResponse;
@@ -24,6 +25,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -78,6 +82,19 @@ public class MatchingService {
         sendMatchingNotification(matching, MatchingStatus.PENDING);
 
         return new MatchingResponse(matching);
+    }
+
+    // 매칭 기록 조회 - 취소, 거절 된 매칭을 제외하고 조회
+    public List<MatchingListResponse> getMatchingList(String username) {
+        List<Matching> matchings = matchingRepository.findActiveMatchingsByUsername(username);
+
+        return matchings.stream()
+                .map(matching -> MatchingListResponse.builder()
+                        .matchingId(matching.getId())
+                        .title(matching.getItem().getTitle())
+                        .status(matching.getStatus())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     // 매칭 자세한 내용 - 매칭 수락시 화면

--- a/src/main/java/com/ktb/joing/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/ktb/joing/domain/notification/controller/NotificationController.java
@@ -1,0 +1,29 @@
+package com.ktb.joing.domain.notification.controller;
+
+import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
+import com.ktb.joing.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notification")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    //매칭 알림 - SSE 구독 엔드포인트
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
+        return notificationService.subscribe(customOAuth2User.getUsername(), lastEventId);
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/ktb/joing/domain/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,21 @@
+package com.ktb.joing.domain.notification.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationResponse {
+    private Long notificationId;
+    private String content;
+    private String relatedUrl;
+
+    @Builder
+    public NotificationResponse(Long notificationId, String content, String relatedUrl) {
+        this.notificationId = notificationId;
+        this.content = content;
+        this.relatedUrl = relatedUrl;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/notification/entity/Notification.java
+++ b/src/main/java/com/ktb/joing/domain/notification/entity/Notification.java
@@ -1,0 +1,47 @@
+package com.ktb.joing.domain.notification.entity;
+
+import com.ktb.joing.common.model.BaseTimeEntity;
+import com.ktb.joing.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+    private String relatedUrl;
+
+    @Column(nullable = false)
+    private boolean isRead;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User receiver;
+
+    @Builder
+    public Notification(String content, String relatedUrl, boolean isRead, User receiver) {
+        this.content = content;
+        this.relatedUrl = relatedUrl;
+        this.isRead = isRead;
+        this.receiver = receiver;
+    }
+
+    public void read() {
+        isRead = true;
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/ktb/joing/domain/notification/repository/EmitterRepository.java
@@ -1,0 +1,21 @@
+package com.ktb.joing.domain.notification.repository;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+
+public interface EmitterRepository {
+    SseEmitter save(String emitterId, SseEmitter sseEmitter);
+
+    void saveEventCache(String eventCacheId, Object event);
+
+    Map<String, SseEmitter> findAllEmitterByUserId(String userId);
+
+    Map<String, Object> findAllEventCacheByUserId(String userId);
+
+    void deleteById(String emitterId);
+
+    void deleteAllEmitterByUserId(String userId);
+
+    void deleteAllEventCacheByUserId(String userId);
+}

--- a/src/main/java/com/ktb/joing/domain/notification/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/com/ktb/joing/domain/notification/repository/EmitterRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.ktb.joing.domain.notification.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+public class EmitterRepositoryImpl implements EmitterRepository {
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+    @Override
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        emitters.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+    @Override
+    public void saveEventCache(String eventCacheId, Object event) {
+        eventCache.put(eventCacheId, event);
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllEmitterByUserId(String userId) {
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(userId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public Map<String, Object> findAllEventCacheByUserId(String userId) {
+        return eventCache.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(userId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void deleteById(String emitterId) {
+        emitters.remove(emitterId);
+    }
+
+    @Override
+    public void deleteAllEmitterByUserId(String userId) {
+        List<String> emitterIds = emitters.keySet().stream()
+                .filter(key -> key.startsWith(userId))
+                .toList();
+
+        emitterIds.forEach(emitters::remove);
+    }
+
+    @Override
+    public void deleteAllEventCacheByUserId(String userId) {
+        List<String> eventIds = eventCache.keySet().stream()
+                .filter(key -> key.startsWith(userId))
+                .toList();
+
+        eventIds.forEach(eventCache::remove);
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ktb/joing/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.ktb.joing.domain.notification.repository;
+
+import com.ktb.joing.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/ktb/joing/domain/notification/service/NotificationConverter.java
+++ b/src/main/java/com/ktb/joing/domain/notification/service/NotificationConverter.java
@@ -1,0 +1,14 @@
+package com.ktb.joing.domain.notification.service;
+
+import com.ktb.joing.domain.notification.dto.response.NotificationResponse;
+import com.ktb.joing.domain.notification.entity.Notification;
+
+public class NotificationConverter {
+    public static NotificationResponse toCreateNotificationDTO(Notification notification){
+        return NotificationResponse.builder()
+                .notificationId(notification.getId())
+                .content(notification.getContent())
+                .relatedUrl(notification.getRelatedUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/ktb/joing/domain/notification/service/NotificationService.java
@@ -1,0 +1,88 @@
+package com.ktb.joing.domain.notification.service;
+
+import com.ktb.joing.domain.notification.entity.Notification;
+import com.ktb.joing.domain.notification.repository.EmitterRepository;
+import com.ktb.joing.domain.notification.repository.NotificationRepository;
+import com.ktb.joing.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+    private final EmitterRepository emitterRepository;
+    private static final Long timeoutMillis = 60L * 1000 * 60;
+
+    public SseEmitter subscribe(String username, String lastEventId) {
+        String emitterId = makeTimeIncludeId(username);
+        SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(timeoutMillis));
+        emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
+        emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+
+        String eventId = makeTimeIncludeId(username);
+        sendNotification(emitter, eventId,
+                emitterId, "EventStream Created. [userId=%s]".formatted(username));
+
+        if (hasLostData(lastEventId)) {
+            sendLostData(lastEventId, username, emitterId, emitter);
+        }
+
+        return emitter;
+    }
+
+    public void send(User receiver, String content, String relatedUrl) {
+        Notification notification = notificationRepository
+                .save(createNotification(receiver, content, relatedUrl));
+
+        String receiverId = String.valueOf(receiver.getUsername());
+        String eventId = makeTimeIncludeId(receiver.getUsername());
+        Map<String, SseEmitter> emitters = emitterRepository.findAllEmitterByUserId(receiverId);
+        emitters.forEach(
+                (id, emitter) -> {
+                    emitterRepository.saveEventCache(id, notification);
+                    sendNotification(emitter, eventId, id,
+                            NotificationConverter.toCreateNotificationDTO(notification));
+                }
+        );
+    }
+
+    private String makeTimeIncludeId(String userName) {
+        return userName + "_" + System.currentTimeMillis();
+    }
+
+    private void sendNotification(SseEmitter emitter, String eventId, String emitterId, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(eventId)
+                    .data(data));
+        } catch (IOException e) {
+            emitterRepository.deleteById(emitterId);
+        }
+    }
+
+    private boolean hasLostData(String lastEventId) {
+        return !lastEventId.isEmpty();
+    }
+
+    private void sendLostData(String lastEventId, String username, String emitterId, SseEmitter emitter) {
+        Map<String, Object> eventCaches = emitterRepository
+                .findAllEventCacheByUserId(String.valueOf(username));
+        eventCaches.entrySet().stream()
+                .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                .forEach(entry -> sendNotification(emitter, entry.getKey(), emitterId, entry.getValue()));
+    }
+
+    private Notification createNotification(User receiver, String content, String url) {
+        return Notification.builder()
+                .receiver(receiver)
+                .content(content)
+                .relatedUrl(url)
+                .isRead(false)
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #JOING-48

<br/>

## 📝 작업 내용

> 아래와 같은 매칭 기능을 구현하였습니다.
> 매칭 요청 생성 (양방향 요청 : 기획자 -> 크리에이터, 크리에이터 -> 기획자), 매칭 상태 조회, 매칭 요청 취소, 매칭 응답에 따른 상태 변경 (수락/거절) 기능을 제공합니다.
> SSE를 활용하여 실시간 매칭 알림 기능 구현하였습니다.
> 매칭 요청/수락/거절/취소 시 알림 전송을 하도록 하였습니다.

<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 
