### PR TITLE
JOING-66 feat: 닉네임 중복 체크 API 구현

### DIFF
--- a/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
                 .securityMatcher("/**") // 모든 요청에 대해
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/healthz", "/oauth2/**", "/login/**").permitAll()
+                        .requestMatchers("/api/v1/users/exists").permitAll()
                         .requestMatchers("/api/v1/users/evaluation/**").permitAll() // AI 서버 관련 엔드 포인트
                         .requestMatchers("/api/v1/items/*/evaluation").permitAll()
                         .requestMatchers("/api/v1/items/*/summary").permitAll()

--- a/src/main/java/com/ktb/joing/domain/user/controller/UserController.java
+++ b/src/main/java/com/ktb/joing/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.ktb.joing.domain.user.dto.request.CreatorUpdateRequest;
 import com.ktb.joing.domain.user.dto.request.ProductManagerSignupRequest;
 import com.ktb.joing.domain.user.dto.request.ProductManagerUpdateRequest;
 import com.ktb.joing.domain.user.dto.response.CreatorResponse;
+import com.ktb.joing.domain.user.dto.response.NicknameAvailableResponse;
 import com.ktb.joing.domain.user.dto.response.ProductManagerResponse;
 import com.ktb.joing.domain.user.dto.response.SignupResponse;
 import com.ktb.joing.domain.user.dto.response.ProfileEvaluationResponse;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
@@ -82,6 +84,11 @@ public class UserController {
             @PathVariable String channelId) {
         return userService.profileEvaluation(channelId)
                 .map(ResponseEntity::ok);
+    }
+
+    @GetMapping("/exists")
+    public ResponseEntity<NicknameAvailableResponse> checkNicknameDuplicate(@RequestParam String nickname) {
+        return ResponseEntity.ok(userService.checkNicknameDuplicate(nickname));
     }
 
 }

--- a/src/main/java/com/ktb/joing/domain/user/dto/response/NicknameAvailableResponse.java
+++ b/src/main/java/com/ktb/joing/domain/user/dto/response/NicknameAvailableResponse.java
@@ -1,0 +1,17 @@
+package com.ktb.joing.domain.user.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NicknameAvailableResponse {
+    private Boolean available;
+
+    @Builder
+    public NicknameAvailableResponse(Boolean available) {
+        this.available = available;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/user/service/UserService.java
+++ b/src/main/java/com/ktb/joing/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.ktb.joing.domain.user.dto.request.CreatorUpdateRequest;
 import com.ktb.joing.domain.user.dto.request.ProductManagerSignupRequest;
 import com.ktb.joing.domain.user.dto.request.ProductManagerUpdateRequest;
 import com.ktb.joing.domain.user.dto.response.CreatorResponse;
+import com.ktb.joing.domain.user.dto.response.NicknameAvailableResponse;
 import com.ktb.joing.domain.user.dto.response.ProductManagerResponse;
 import com.ktb.joing.domain.user.dto.request.ProfileEvaluationRequest;
 import com.ktb.joing.domain.user.dto.response.ProfileEvaluationResponse;
@@ -45,8 +46,6 @@ public class UserService {
         TempUser tempUser = tempUserRepository.findById(username)
                 .orElseThrow(() -> new UserException(UserErrorCode.TEMP_USER_NOT_FOUND));
 
-        validateDuplicateNickname(request.getNickname());
-
         Creator creator = Creator.builder()
                 .username(tempUser.getId())
                 .email(request.getEmail())
@@ -74,8 +73,6 @@ public class UserService {
     public SignupResponse productManagerSignUp(String username, ProductManagerSignupRequest request) {
         TempUser tempUser = tempUserRepository.findById(username)
                 .orElseThrow(() -> new UserException(UserErrorCode.TEMP_USER_NOT_FOUND));
-
-        validateDuplicateNickname(request.getNickname());
 
         ProductManager user = ProductManager.builder()
                 .username(tempUser.getId())
@@ -121,10 +118,6 @@ public class UserService {
         Creator creator = creatorRepository.findByUsername(username)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        if (request.getNickname() != null) {
-            validateDuplicateNickname(request.getNickname());
-        }
-
         creator.update(request);
         return CreatorResponse.builder().creator(creator).build();
     }
@@ -135,19 +128,17 @@ public class UserService {
         ProductManager productManager = productManagerRepository.findByUsername(username)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        if (request.getNickname() != null) {
-            validateDuplicateNickname(request.getNickname());
-        }
-
         productManager.update(request);
         return ProductManagerResponse.builder().productManager(productManager).build();
     }
 
     // 닉네임 중복 확인
-    private void validateDuplicateNickname(String nickname) {
-        if (userRepository.existsByNickname(nickname)) {
-            throw new UserException(UserErrorCode.DUPLICATED_NICKNAME);
-        }
+    public NicknameAvailableResponse checkNicknameDuplicate(String nickname) {
+        boolean available = !userRepository.existsByNickname(nickname);
+
+        return NicknameAvailableResponse.builder()
+                .available(available)
+                .build();
     }
 
     // 크리에이터 프로필(채널) 유해성 검사
@@ -161,5 +152,4 @@ public class UserService {
                     return new UserException(UserErrorCode.PROFILE_EVALUATION_FAILED);
                 });
     }
-
 }


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> #JOING-66

<br/>

## 📝 작업 내용

> 기존 닉네임 중복 확인 로직을 별도 API로 분리
> Security 설정에서 해당 엔드포인트 permitAll 처리

<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 
