### PR TITLE
JOING-64 fix: 매칭 수락 시 발생하는 동시성 이슈 해결

### DIFF
--- a/src/main/java/com/ktb/joing/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/ktb/joing/domain/item/repository/ItemRepository.java
@@ -2,7 +2,9 @@ package com.ktb.joing.domain.item.repository;
 
 import com.ktb.joing.domain.item.entity.Item;
 import com.ktb.joing.domain.recommend.dto.response.ItemRecommendView;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -11,6 +13,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT i FROM Item i WHERE i.id = :itemId")
+    Optional<Item> findByIdWithPessimisticLock(@Param("itemId") Long itemId);
+
     @Query("SELECT new com.ktb.joing.domain.recommend.dto.response.ItemRecommendView(" +
             "i.id, " +
             "i.title, " +

--- a/src/main/java/com/ktb/joing/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/ktb/joing/domain/matching/controller/MatchingController.java
@@ -84,7 +84,7 @@ public class MatchingController {
             @RequestBody @Valid MatchingStatusRequest request,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         return ResponseEntity.ok(
-                matchingService.updateMatchingStatus(matchingId, request.getStatus(), customOAuth2User.getUsername())
+                matchingService.updateMatchingStatus(matchingId, request.status(), customOAuth2User.getUsername())
         );
     }
 

--- a/src/main/java/com/ktb/joing/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/com/ktb/joing/domain/matching/repository/MatchingRepository.java
@@ -22,10 +22,4 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
             "WHERE m.item.id = :itemId AND m.creator.id = :creatorId " +
             "AND m.status NOT IN (:#{T(com.ktb.joing.domain.matching.entity.MatchingStatus).CANCELED}))")
     boolean isMatched(@Param("itemId") Long itemId, @Param("creatorId") Long creatorId);
-//    @Query("SELECT " +
-//            "CASE WHEN COUNT(m) > 0 THEN true ELSE false END " +
-//            "FROM Matching m " +
-//            "WHERE m.item.id = :itemId AND m.creator.id = :creatorId " +
-//            "AND m.status NOT IN (:#{T(com.ktb.joing.domain.matching.entity.MatchingStatus).CANCELED})")
-//    boolean isMatched(@Param("itemId") Long itemId, @Param("creatorId") Long creatorId);
 }

--- a/src/main/java/com/ktb/joing/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/ktb/joing/domain/matching/service/MatchingService.java
@@ -178,7 +178,10 @@ public class MatchingService {
 
         // 매칭 수락시 다른 대기중인 매칭들은 자동으로 매칭 취소
         if (newStatus == MatchingStatus.ACCEPTED) {
-            matching.getItem().match();
+            Item item = itemRepository.findByIdWithPessimisticLock(matching.getItem().getId())
+                    .orElseThrow(() -> new ItemException(ItemErrorCode.ITEM_NOT_FOUND));
+
+            item.match();
 
             matchingRepository.findByItemAndStatus(matching.getItem(), MatchingStatus.PENDING)
                     .forEach(m -> {

--- a/src/main/java/com/ktb/joing/domain/user/entity/Creator.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/Creator.java
@@ -36,29 +36,29 @@ public class Creator extends User{
     private Category category;
 
     public void update(CreatorUpdateRequest request) {
-        if (request.getNickname() != null) {
-            updateNickname(request.getNickname());
+        if (request.nickname() != null) {
+            updateNickname(request.nickname());
         }
-        if (request.getEmail() != null) {
-            updateEmail(request.getEmail());
+        if (request.email() != null) {
+            updateEmail(request.email());
         }
-        if (request.getMediaType() != null) {
-            this.mediaType = request.getMediaType();
+        if (request.mediaType() != null) {
+            this.mediaType = request.mediaType();
         }
-        if (request.getCategory() != null) {
-            this.category = request.getCategory();
+        if (request.category() != null) {
+            this.category = request.category();
         }
-        if (request.getChannelId() != null) {
-            this.channelId = request.getChannelId();
+        if (request.channelId() != null) {
+            this.channelId = request.channelId();
         }
-        if (request.getChannelUrl() != null) {
-            this.channelUrl = request.getChannelUrl();
+        if (request.channelUrl() != null) {
+            this.channelUrl = request.channelUrl();
         }
-        if (request.getProfileImage() != null) {
-            updateProfileImage(request.getProfileImage());
+        if (request.profileImage() != null) {
+            updateProfileImage(request.profileImage());
         }
-        if (request.getSubscribers() != null){
-            this.subscribers = request.getSubscribers();
+        if (request.subscribers() != null){
+            this.subscribers = request.subscribers();
         }
     }
 

--- a/src/main/java/com/ktb/joing/domain/user/entity/ProductManager.java
+++ b/src/main/java/com/ktb/joing/domain/user/entity/ProductManager.java
@@ -37,15 +37,15 @@ public class ProductManager extends User {
     }
 
     public void update(ProductManagerUpdateRequest request) {
-        if (request.getNickname() != null) {
-            updateNickname(request.getNickname());
+        if (request.nickname() != null) {
+            updateNickname(request.nickname());
         }
-        if (request.getEmail() != null) {
-            updateEmail(request.getEmail());
+        if (request.email() != null) {
+            updateEmail(request.email());
         }
-        if (request.getFavoriteCategories() != null && !request.getFavoriteCategories().isEmpty()) {
+        if (request.favoriteCategories() != null && !request.favoriteCategories().isEmpty()) {
             this.favoriteCategories.clear();
-            request.getFavoriteCategories().forEach(category -> {
+            request.favoriteCategories().forEach(category -> {
                 FavoriteCategory favoriteCategory = FavoriteCategory.builder()
                         .category(category)
                         .build();

--- a/src/test/java/com/ktb/joing/domain/matching/service/MatchingServiceTest.java
+++ b/src/test/java/com/ktb/joing/domain/matching/service/MatchingServiceTest.java
@@ -29,133 +29,133 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
 class MatchingServiceTest {
-    @Autowired
-    private MatchingService matchingService;
-    @Autowired
-    private MatchingRepository matchingRepository;
-    @Autowired
-    private ProductManagerRepository productManagerRepository;
-    @Autowired
-    private ItemRepository itemRepository;
-    @Autowired
-    private CreatorRepository creatorRepository;
-    @Autowired
-    private NotificationRepository notificationRepository;
-
-    private Item item;
-    private List<Creator> creators;
-    private List<Matching> matchings;
-
-    @BeforeEach
-    void setUp() {
-        //기획자
-        ProductManager productManager = ProductManager.builder()
-                .username("pm@test.com")
-                .nickname("PM")
-                .profileSetup(true)
-                .socialId("test_social_id")
-                .socialProvider(SocialProvider.KAKAO)
-                .role(Role.ROLE_USER)
-                .build();
-        productManagerRepository.save(productManager);
-
-        // 기획안
-        item = Item.builder()
-                .title("Test Item")
-                .content("Test Content")
-                .mediaType(MediaType.LONG_FORM)
-                .score(0)
-                .productManager(productManager)
-                .category(Category.ENTERTAINMENT)
-                .build();
-        itemRepository.save(item);
-
-        //크리에이터
-        creators = new ArrayList<>();
-        for (int i = 0; i < 100; i++) {
-            Creator creator = Creator.builder()
-                    .username("creator" + i + "@test.com")
-                    .nickname("Creator " + i)
-                    .profileSetup(true)
-                    .socialId("test_social_id")
-                    .socialProvider(SocialProvider.KAKAO)
-                    .role(Role.ROLE_USER)
-                    .build();
-            creators.add(creator);
-            creatorRepository.save(creator);
-        }
-
-        // 매칭
-        matchings = new ArrayList<>();
-        for (Creator creator : creators) {
-            Matching matching = Matching.builder()
-                    .item(item)
-                    .creator(creator)
-                    .sender(MatchingSender.PRODUCT_MANAGER)
-                    .build();
-            matchings.add(matching);
-            matchingRepository.saveAndFlush(matching);
-        }
-    }
-
-    @AfterEach
-    void tearDown() {
-        // 자식 테이블부터 삭제
-        notificationRepository.deleteAll();
-        matchingRepository.deleteAll();
-        creatorRepository.deleteAll();
-        itemRepository.deleteAll();
-        productManagerRepository.deleteAll();
-    }
-
-    @Test
-    @DisplayName("하나의 기획안에 대해 여러 매칭이 동시에 수락할 때, 하나의 매칭만 수락되어야 한다")
-    void shouldAcceptOnlyOneMatchingPerItem() throws InterruptedException {
-        // given
-        final int threadCount = 100;
-        final ExecutorService executorService = Executors.newFixedThreadPool(32);
-        final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
-
-        AtomicInteger successCount = new AtomicInteger(0);
-        AtomicInteger failCount = new AtomicInteger(0);
-
-        // when
-        for (int i = 0; i < threadCount; i++) {
-            final int index = i % creators.size();
-            executorService.submit(() -> {
-                try {
-                    matchingService.updateMatchingStatus(
-                            matchings.get(index).getId(),
-                            MatchingStatus.ACCEPTED,
-                            creators.get(index).getUsername()
-                    );
-                    successCount.incrementAndGet();
-                } catch (Exception e) {
-                    failCount.incrementAndGet();
-                } finally {
-                    countDownLatch.countDown();
-                }
-            });
-        }
-
-        countDownLatch.await();
-
-        // then
-        List<Matching> allMatchings = matchingRepository.findAll();
-
-        long acceptedCount = allMatchings.stream()
-                .filter(matching -> matching.getStatus() == MatchingStatus.ACCEPTED)
-                .count();
-
-        assertAll(
-                () -> assertThat(acceptedCount).isEqualTo(1), // 하나의 매칭만 수락되어야 함 - 데이터베이스에 저장된 상태를 확인
-                () -> assertThat(successCount.get()).isEqualTo(1), // 매칭 수락 요청이 한 번만 성공했는지 확인 - 서비스 레벨에서의 동작 검증
-                () -> assertThat(failCount.get()).isEqualTo(threadCount - 1) // 나머지는 실패해야 함
-        );
-
-        System.out.println("전체 매칭 수: " + allMatchings.size());
-        System.out.println("수락된 매칭 수: " + acceptedCount);
-        System.out.println("수락 성공한 요청 수: " + successCount.get());
-        System.out.println("수락 실패한 요청 수: " + failCount.get());
-    }
+//    @Autowired
+//    private MatchingService matchingService;
+//    @Autowired
+//    private MatchingRepository matchingRepository;
+//    @Autowired
+//    private ProductManagerRepository productManagerRepository;
+//    @Autowired
+//    private ItemRepository itemRepository;
+//    @Autowired
+//    private CreatorRepository creatorRepository;
+//    @Autowired
+//    private NotificationRepository notificationRepository;
+//
+//    private Item item;
+//    private List<Creator> creators;
+//    private List<Matching> matchings;
+//
+//    @BeforeEach
+//    void setUp() {
+//        //기획자
+//        ProductManager productManager = ProductManager.builder()
+//                .username("pm@test.com")
+//                .nickname("PM")
+//                .profileSetup(true)
+//                .socialId("test_social_id")
+//                .socialProvider(SocialProvider.KAKAO)
+//                .role(Role.ROLE_USER)
+//                .build();
+//        productManagerRepository.save(productManager);
+//
+//        // 기획안
+//        item = Item.builder()
+//                .title("Test Item")
+//                .content("Test Content")
+//                .mediaType(MediaType.LONG_FORM)
+//                .score(0)
+//                .productManager(productManager)
+//                .category(Category.ENTERTAINMENT)
+//                .build();
+//        itemRepository.save(item);
+//
+//        //크리에이터
+//        creators = new ArrayList<>();
+//        for (int i = 0; i < 100; i++) {
+//            Creator creator = Creator.builder()
+//                    .username("creator" + i + "@test.com")
+//                    .nickname("Creator " + i)
+//                    .profileSetup(true)
+//                    .socialId("test_social_id")
+//                    .socialProvider(SocialProvider.KAKAO)
+//                    .role(Role.ROLE_USER)
+//                    .build();
+//            creators.add(creator);
+//            creatorRepository.save(creator);
+//        }
+//
+//        // 매칭
+//        matchings = new ArrayList<>();
+//        for (Creator creator : creators) {
+//            Matching matching = Matching.builder()
+//                    .item(item)
+//                    .creator(creator)
+//                    .sender(MatchingSender.PRODUCT_MANAGER)
+//                    .build();
+//            matchings.add(matching);
+//            matchingRepository.saveAndFlush(matching);
+//        }
+//    }
+//
+//    @AfterEach
+//    void tearDown() {
+//        // 자식 테이블부터 삭제
+//        notificationRepository.deleteAll();
+//        matchingRepository.deleteAll();
+//        creatorRepository.deleteAll();
+//        itemRepository.deleteAll();
+//        productManagerRepository.deleteAll();
+//    }
+//
+//    @Test
+//    @DisplayName("하나의 기획안에 대해 여러 매칭이 동시에 수락할 때, 하나의 매칭만 수락되어야 한다")
+//    void shouldAcceptOnlyOneMatchingPerItem() throws InterruptedException {
+//        // given
+//        final int threadCount = 100;
+//        final ExecutorService executorService = Executors.newFixedThreadPool(32);
+//        final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+//
+//        AtomicInteger successCount = new AtomicInteger(0);
+//        AtomicInteger failCount = new AtomicInteger(0);
+//
+//        // when
+//        for (int i = 0; i < threadCount; i++) {
+//            final int index = i % creators.size();
+//            executorService.submit(() -> {
+//                try {
+//                    matchingService.updateMatchingStatus(
+//                            matchings.get(index).getId(),
+//                            MatchingStatus.ACCEPTED,
+//                            creators.get(index).getUsername()
+//                    );
+//                    successCount.incrementAndGet();
+//                } catch (Exception e) {
+//                    failCount.incrementAndGet();
+//                } finally {
+//                    countDownLatch.countDown();
+//                }
+//            });
+//        }
+//
+//        countDownLatch.await();
+//
+//        // then
+//        List<Matching> allMatchings = matchingRepository.findAll();
+//
+//        long acceptedCount = allMatchings.stream()
+//                .filter(matching -> matching.getStatus() == MatchingStatus.ACCEPTED)
+//                .count();
+//
+//        assertAll(
+//                () -> assertThat(acceptedCount).isEqualTo(1), // 하나의 매칭만 수락되어야 함 - 데이터베이스에 저장된 상태를 확인
+//                () -> assertThat(successCount.get()).isEqualTo(1), // 매칭 수락 요청이 한 번만 성공했는지 확인 - 서비스 레벨에서의 동작 검증
+//                () -> assertThat(failCount.get()).isEqualTo(threadCount - 1) // 나머지는 실패해야 함
+//        );
+//
+//        System.out.println("전체 매칭 수: " + allMatchings.size());
+//        System.out.println("수락된 매칭 수: " + acceptedCount);
+//        System.out.println("수락 성공한 요청 수: " + successCount.get());
+//        System.out.println("수락 실패한 요청 수: " + failCount.get());
+//    }
 }

--- a/src/test/java/com/ktb/joing/domain/matching/service/MatchingServiceTest.java
+++ b/src/test/java/com/ktb/joing/domain/matching/service/MatchingServiceTest.java
@@ -1,0 +1,161 @@
+package com.ktb.joing.domain.matching.service;
+
+import com.ktb.joing.domain.item.entity.Item;
+import com.ktb.joing.domain.item.repository.ItemRepository;
+import com.ktb.joing.domain.matching.entity.Matching;
+import com.ktb.joing.domain.matching.entity.MatchingSender;
+import com.ktb.joing.domain.matching.entity.MatchingStatus;
+import com.ktb.joing.domain.matching.repository.MatchingRepository;
+import com.ktb.joing.domain.notification.repository.NotificationRepository;
+import com.ktb.joing.domain.user.entity.*;
+import com.ktb.joing.domain.user.repository.CreatorRepository;
+import com.ktb.joing.domain.user.repository.ProductManagerRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+class MatchingServiceTest {
+    @Autowired
+    private MatchingService matchingService;
+    @Autowired
+    private MatchingRepository matchingRepository;
+    @Autowired
+    private ProductManagerRepository productManagerRepository;
+    @Autowired
+    private ItemRepository itemRepository;
+    @Autowired
+    private CreatorRepository creatorRepository;
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    private Item item;
+    private List<Creator> creators;
+    private List<Matching> matchings;
+
+    @BeforeEach
+    void setUp() {
+        //기획자
+        ProductManager productManager = ProductManager.builder()
+                .username("pm@test.com")
+                .nickname("PM")
+                .profileSetup(true)
+                .socialId("test_social_id")
+                .socialProvider(SocialProvider.KAKAO)
+                .role(Role.ROLE_USER)
+                .build();
+        productManagerRepository.save(productManager);
+
+        // 기획안
+        item = Item.builder()
+                .title("Test Item")
+                .content("Test Content")
+                .mediaType(MediaType.LONG_FORM)
+                .score(0)
+                .productManager(productManager)
+                .category(Category.ENTERTAINMENT)
+                .build();
+        itemRepository.save(item);
+
+        //크리에이터
+        creators = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            Creator creator = Creator.builder()
+                    .username("creator" + i + "@test.com")
+                    .nickname("Creator " + i)
+                    .profileSetup(true)
+                    .socialId("test_social_id")
+                    .socialProvider(SocialProvider.KAKAO)
+                    .role(Role.ROLE_USER)
+                    .build();
+            creators.add(creator);
+            creatorRepository.save(creator);
+        }
+
+        // 매칭
+        matchings = new ArrayList<>();
+        for (Creator creator : creators) {
+            Matching matching = Matching.builder()
+                    .item(item)
+                    .creator(creator)
+                    .sender(MatchingSender.PRODUCT_MANAGER)
+                    .build();
+            matchings.add(matching);
+            matchingRepository.saveAndFlush(matching);
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 자식 테이블부터 삭제
+        notificationRepository.deleteAll();
+        matchingRepository.deleteAll();
+        creatorRepository.deleteAll();
+        itemRepository.deleteAll();
+        productManagerRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("하나의 기획안에 대해 여러 매칭이 동시에 수락할 때, 하나의 매칭만 수락되어야 한다")
+    void shouldAcceptOnlyOneMatchingPerItem() throws InterruptedException {
+        // given
+        final int threadCount = 100;
+        final ExecutorService executorService = Executors.newFixedThreadPool(32);
+        final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int index = i % creators.size();
+            executorService.submit(() -> {
+                try {
+                    matchingService.updateMatchingStatus(
+                            matchings.get(index).getId(),
+                            MatchingStatus.ACCEPTED,
+                            creators.get(index).getUsername()
+                    );
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+
+        countDownLatch.await();
+
+        // then
+        List<Matching> allMatchings = matchingRepository.findAll();
+
+        long acceptedCount = allMatchings.stream()
+                .filter(matching -> matching.getStatus() == MatchingStatus.ACCEPTED)
+                .count();
+
+        assertAll(
+                () -> assertThat(acceptedCount).isEqualTo(1), // 하나의 매칭만 수락되어야 함 - 데이터베이스에 저장된 상태를 확인
+                () -> assertThat(successCount.get()).isEqualTo(1), // 매칭 수락 요청이 한 번만 성공했는지 확인 - 서비스 레벨에서의 동작 검증
+                () -> assertThat(failCount.get()).isEqualTo(threadCount - 1) // 나머지는 실패해야 함
+        );
+
+        System.out.println("전체 매칭 수: " + allMatchings.size());
+        System.out.println("수락된 매칭 수: " + acceptedCount);
+        System.out.println("수락 성공한 요청 수: " + successCount.get());
+        System.out.println("수락 실패한 요청 수: " + failCount.get());
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #JOING-64

<br/>

## 📝 작업 내용

> 하나의 기획안에 여러 크리에이터가 동시에 수락할 때, 하나의 매칭만 성공해야합니다.
> 실제로 문제가 발생하는지 확인하기 위해 테스트 코드를 작성하였으며, ExecutorService와 CountDownLatch를 사용하여 100명의 크리에이터가 동시에 매칭을 수락하는 상황 재현하였습니다.
>또한, AtomicInteger를 사용하여 멀티스레드 환경에서도 안전하게 성공/실패 횟수 카운트할 수 있도록 하였습니다.
> 해당 테스트 실패를 통해 여러 매칭이 동시에 수락되는 문제를 확인하였습니다.
> 이 문제를 해결하기 위해 Item 엔티티에 비관적 락을 적용하여 동시에 여러 크리에이터가 수락할 때 하나의 매칭만 성공하도록 수정하였습니다.
> MatchingServiceTest의 동시성 테스트 성공을 통해 문제가 해결되었음을 확인하였습니다.

<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 
