### PR TITLE
JOING-68 feat: 1대1 채팅 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	//webflux (WebClient)
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	//webSocket (stomp)
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 	//swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 

--- a/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/joing/common/config/SecurityConfig.java
@@ -75,6 +75,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/items/*/summary").permitAll()
                         .requestMatchers("/api/v1/recommendations/**").permitAll()
                         .requestMatchers("/signup/**", "/api/v1/users/signup/**").hasRole("TEMP_USER")
+                        .requestMatchers("/ws/**").permitAll()
                         .anyRequest().authenticated()
                 );
         //세션 설정 : STATELESS

--- a/src/main/java/com/ktb/joing/common/config/WebSocketConfig.java
+++ b/src/main/java/com/ktb/joing/common/config/WebSocketConfig.java
@@ -1,0 +1,36 @@
+package com.ktb.joing.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketInterceptor websocketInterceptor;
+    private final WebSocketErrorHandler websocketErrorHandler;
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/connect")
+                .setAllowedOrigins("*"); //cors 허용 설정
+        registry.setErrorHandler(websocketErrorHandler);
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/subscribe");
+        registry.setApplicationDestinationPrefixes("/publish");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(websocketInterceptor);
+    }
+}

--- a/src/main/java/com/ktb/joing/common/config/WebSocketErrorHandler.java
+++ b/src/main/java/com/ktb/joing/common/config/WebSocketErrorHandler.java
@@ -1,0 +1,25 @@
+package com.ktb.joing.common.config;
+
+import com.ktb.joing.domain.auth.exception.AuthException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import static com.ktb.joing.domain.auth.exception.AuthErrorCode.INVALID_JWT;
+
+@Component
+@Slf4j
+public class WebSocketErrorHandler extends StompSubProtocolErrorHandler {
+
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
+        // 토큰 문제로 예외 발생시 예외를 재정의해서 위임
+        if (ex.getCause() instanceof AuthException) {
+            log.info(ex.getMessage());
+            ex = new MessageDeliveryException(INVALID_JWT.getMessage());
+        }
+        return super.handleClientMessageProcessingError(clientMessage, ex);
+    }
+}

--- a/src/main/java/com/ktb/joing/common/config/WebSocketInterceptor.java
+++ b/src/main/java/com/ktb/joing/common/config/WebSocketInterceptor.java
@@ -1,0 +1,51 @@
+package com.ktb.joing.common.config;
+
+import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
+import com.ktb.joing.domain.auth.dto.UserDto;
+import com.ktb.joing.domain.auth.jwt.JwtUtil;
+import com.ktb.joing.domain.user.entity.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketInterceptor implements ChannelInterceptor {
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        // Connect 연결 요청이면 InboundChannel에 메세지를 보내기전에 user 인증객체를 등록
+        if (accessor.getCommand() == StompCommand.CONNECT) {
+            String token = accessor.getFirstNativeHeader("access");
+            if (token == null || !jwtUtil.isTokenValid(token)) {
+                throw new MessageDeliveryException("Invalid or missing token");
+            }
+            CustomOAuth2User customOAuth2User = getCustomOAuth2User(jwtUtil.getUsernameFromToken(token),
+                    jwtUtil.getRoleFromToken(token));
+            Authentication authentication = getAuthentication(customOAuth2User);
+            accessor.setUser(authentication);
+        }
+        return message;
+    }
+
+    private Authentication getAuthentication(CustomOAuth2User customOAuth2User) {
+        return new UsernamePasswordAuthenticationToken(customOAuth2User, "", customOAuth2User.getAuthorities());
+    }
+
+    private CustomOAuth2User getCustomOAuth2User(String userId, String role) {
+        UserDto userDto = new UserDto();
+        userDto.setUsername(userId);
+        userDto.setRole(Role.valueOf(role));
+        return new CustomOAuth2User(userDto);
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/auth/dto/CustomOAuth2User.java
+++ b/src/main/java/com/ktb/joing/domain/auth/dto/CustomOAuth2User.java
@@ -37,7 +37,7 @@ public class CustomOAuth2User implements OAuth2User {
 
     @Override
     public String getName() {
-        return userDto.getName();
+        return userDto.getUsername();
     }
 
     public String getUsername() {

--- a/src/main/java/com/ktb/joing/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/ktb/joing/domain/chat/controller/ChatController.java
@@ -1,0 +1,27 @@
+package com.ktb.joing.domain.chat.controller;
+
+import com.ktb.joing.domain.chat.dto.request.ChatMessageSocketRequest;
+import com.ktb.joing.domain.chat.service.ChatSocketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+    private final ChatSocketService chatSocketService;
+
+    @MessageMapping("/rooms/{roomId}")
+    public void sendMessage(
+            Principal principal,
+            @DestinationVariable Long roomId,
+            ChatMessageSocketRequest request
+    ) {
+        chatSocketService.sendChat(principal.getName(), roomId, request);
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/ktb/joing/domain/chat/controller/ChatRoomController.java
@@ -1,0 +1,51 @@
+package com.ktb.joing.domain.chat.controller;
+
+import com.ktb.joing.domain.auth.dto.CustomOAuth2User;
+import com.ktb.joing.domain.chat.dto.request.CreateChatRoomRequest;
+import com.ktb.joing.domain.chat.dto.response.ChatRoomDetailResponse;
+import com.ktb.joing.domain.chat.dto.response.CreateChatRoomResponse;
+import com.ktb.joing.domain.chat.service.ChatRoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat/rooms")
+public class ChatRoomController {
+    private final ChatRoomService chatRoomService;
+
+    // 채팅방 생성
+    @PostMapping()
+    public ResponseEntity<CreateChatRoomResponse> createChatRoom(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @RequestBody CreateChatRoomRequest request
+    ) {
+        CreateChatRoomResponse response = chatRoomService.createChatRoom(customOAuth2User.getUsername(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // 채팅방 나가기
+    @PostMapping("/leave/{roomId}")
+    public ResponseEntity<Void> leave(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @PathVariable Long roomId
+    ) {
+        chatRoomService.leave(customOAuth2User.getUsername(), roomId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 참여 채팅방 목록 조회
+    @GetMapping()
+    public ResponseEntity<List<ChatRoomDetailResponse>> findChatRooms(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+    ) {
+        List<ChatRoomDetailResponse> response = chatRoomService.findChatRooms(customOAuth2User.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/chat/dto/request/ChatMessageSocketRequest.java
+++ b/src/main/java/com/ktb/joing/domain/chat/dto/request/ChatMessageSocketRequest.java
@@ -1,0 +1,5 @@
+package com.ktb.joing.domain.chat.dto.request;
+
+public record ChatMessageSocketRequest(
+        String content
+) {}

--- a/src/main/java/com/ktb/joing/domain/chat/dto/request/CreateChatRoomRequest.java
+++ b/src/main/java/com/ktb/joing/domain/chat/dto/request/CreateChatRoomRequest.java
@@ -1,0 +1,7 @@
+package com.ktb.joing.domain.chat.dto.request;
+
+public record CreateChatRoomRequest(
+   Long receiverId,
+   Long itemId,
+   String sender
+) {}

--- a/src/main/java/com/ktb/joing/domain/chat/dto/response/ChatMessageSocketResponse.java
+++ b/src/main/java/com/ktb/joing/domain/chat/dto/response/ChatMessageSocketResponse.java
@@ -1,0 +1,31 @@
+package com.ktb.joing.domain.chat.dto.response;
+
+import com.ktb.joing.domain.chat.entity.MessageType;
+import com.ktb.joing.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageSocketResponse(
+        MessageType messageType,
+        String content,
+        Long senderId,
+        String senderName,
+        String profileImage,
+        LocalDateTime createdAt
+) {
+    public ChatMessageSocketResponse(
+            MessageType messageType,
+            String content,
+            User senderUser,
+            LocalDateTime createdAt
+    ) {
+        this(
+                messageType,
+                content,
+                senderUser.getId(),
+                senderUser.getNickname(),
+                senderUser.getProfileImage(),
+                createdAt
+        );
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/chat/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/com/ktb/joing/domain/chat/dto/response/ChatRoomDetailResponse.java
@@ -1,0 +1,11 @@
+package com.ktb.joing.domain.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomDetailResponse(
+    Long roomId,
+    String receiverName,
+    String receiverProfileImage,
+    String recentMessage,
+    LocalDateTime recentMessageCreateAt
+) {}

--- a/src/main/java/com/ktb/joing/domain/chat/dto/response/CreateChatRoomResponse.java
+++ b/src/main/java/com/ktb/joing/domain/chat/dto/response/CreateChatRoomResponse.java
@@ -1,0 +1,5 @@
+package com.ktb.joing.domain.chat.dto.response;
+
+public record CreateChatRoomResponse (
+        Long roomId
+) {}

--- a/src/main/java/com/ktb/joing/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/ktb/joing/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,42 @@
+package com.ktb.joing.domain.chat.entity;
+
+import com.ktb.joing.common.model.BaseTimeEntity;
+import com.ktb.joing.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
+    private MessageType messageType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User senderUser;
+
+    @Column(length = 2000)
+    private String content;
+
+    @Builder
+    public ChatMessage(ChatRoom chatRoom, MessageType messageType, User senderUser, String content) {
+        this.chatRoom = chatRoom;
+        this.messageType = messageType;
+        this.senderUser = senderUser;
+        this.content = content;
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/ktb/joing/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,67 @@
+package com.ktb.joing.domain.chat.entity;
+
+import com.ktb.joing.domain.chat.exception.ChatErrorCode;
+import com.ktb.joing.domain.chat.exception.ChatException;
+import com.ktb.joing.domain.item.entity.Item;
+import com.ktb.joing.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id")
+    private Item item;  // 기획안 정보
+
+    @OneToMany(mappedBy = "chatRoom", orphanRemoval = true, cascade = CascadeType.ALL)
+    private final List<ChatRoomUser> chatRoomUsers = new ArrayList<>();
+
+    public void addMember(User user,String role) {
+        if (containsUser(user)) {
+            throw new ChatException(ChatErrorCode.ROOM_ACCESS_DENIED);
+        }
+        chatRoomUsers.add(
+                ChatRoomUser.builder()
+                        .chatRoom(this)
+                        .user(user)
+                        .role(role)
+                        .build()
+        );
+    }
+
+    public boolean containsUser(User user) {
+        return chatRoomUsers.stream()
+                .anyMatch(chatRoomMember -> chatRoomMember.hasUser(user));
+    }
+
+    public void removeMember(User member) {
+        chatRoomUsers.stream()
+                .filter(row -> row.hasUser(member))
+                .findAny()
+                .ifPresent(found -> chatRoomUsers.remove(found));
+    }
+
+    public List<User> findMembers() {
+        return chatRoomUsers.stream()
+                .map(ChatRoomUser::getUser)
+                .toList();
+    }
+
+    @Builder
+    public ChatRoom(Item item) {
+        this.item = item;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/chat/entity/ChatRoomUser.java
+++ b/src/main/java/com/ktb/joing/domain/chat/entity/ChatRoomUser.java
@@ -1,0 +1,41 @@
+package com.ktb.joing.domain.chat.entity;
+
+import com.ktb.joing.common.model.BaseTimeEntity;
+import com.ktb.joing.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomUser extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    private String role;
+
+    public boolean hasUser(User user) {
+        if (user == null) {
+            return false;
+        }
+        return this.user.getUsername().equals(user.getUsername());
+    }
+
+    @Builder
+    public ChatRoomUser(ChatRoom chatRoom, User user, String role) {
+        this.chatRoom = chatRoom;
+        this.user = user;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/chat/entity/MessageType.java
+++ b/src/main/java/com/ktb/joing/domain/chat/entity/MessageType.java
@@ -1,0 +1,7 @@
+package com.ktb.joing.domain.chat.entity;
+
+public enum MessageType {
+    ENTER,
+    CHAT,
+    LEAVE
+}

--- a/src/main/java/com/ktb/joing/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/ktb/joing/domain/chat/exception/ChatErrorCode.java
@@ -1,0 +1,17 @@
+package com.ktb.joing.domain.chat.exception;
+
+import com.ktb.joing.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatErrorCode implements ErrorCode {
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다"),
+    CHAT_ROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, "자신이 참여한 채팅방에만 메시지를 보낼 수 있습니다."),
+    ROOM_ACCESS_DENIED(HttpStatus.CONFLICT, "이미 참가한 채팅방입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/ktb/joing/domain/chat/exception/ChatException.java
+++ b/src/main/java/com/ktb/joing/domain/chat/exception/ChatException.java
@@ -1,0 +1,14 @@
+package com.ktb.joing.domain.chat.exception;
+
+import com.ktb.joing.common.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class ChatException  extends BusinessException {
+    private final ChatErrorCode chatErrorCode;
+
+    public ChatException(ChatErrorCode chatErrorCode) {
+        super(chatErrorCode);
+        this.chatErrorCode = chatErrorCode;
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/ktb/joing/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,14 @@
+package com.ktb.joing.domain.chat.repository;
+
+import com.ktb.joing.domain.chat.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    Optional<ChatMessage> findFirstByChatRoomIdOrderByCreatedDateTimeDesc(Long chatRoomId);
+
+    default Optional<ChatMessage> findRecentByChatRoomId(Long chatRoomId) {
+        return findFirstByChatRoomIdOrderByCreatedDateTimeDesc(chatRoomId);
+    }
+}

--- a/src/main/java/com/ktb/joing/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/ktb/joing/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,17 @@
+package com.ktb.joing.domain.chat.repository;
+
+import com.ktb.joing.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    // 특정 사용자의 모든 채팅방을 조회
+    @Query("SELECT chatRoomUser.chatRoom " +
+            "FROM ChatRoomUser chatRoomUser " +
+            "WHERE chatRoomUser.user.username = :username")
+    List<ChatRoom> findMine(@Param("username") String username);
+}

--- a/src/main/java/com/ktb/joing/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/ktb/joing/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,110 @@
+package com.ktb.joing.domain.chat.service;
+
+import com.ktb.joing.domain.chat.dto.request.CreateChatRoomRequest;
+import com.ktb.joing.domain.chat.dto.response.ChatRoomDetailResponse;
+import com.ktb.joing.domain.chat.dto.response.CreateChatRoomResponse;
+import com.ktb.joing.domain.chat.entity.ChatMessage;
+import com.ktb.joing.domain.chat.entity.ChatRoom;
+import com.ktb.joing.domain.chat.exception.ChatErrorCode;
+import com.ktb.joing.domain.chat.exception.ChatException;
+import com.ktb.joing.domain.chat.repository.ChatMessageRepository;
+import com.ktb.joing.domain.chat.repository.ChatRoomRepository;
+import com.ktb.joing.domain.item.entity.Item;
+import com.ktb.joing.domain.item.exception.ItemErrorCode;
+import com.ktb.joing.domain.item.exception.ItemException;
+import com.ktb.joing.domain.item.repository.ItemRepository;
+import com.ktb.joing.domain.user.entity.User;
+import com.ktb.joing.domain.user.exception.UserErrorCode;
+import com.ktb.joing.domain.user.exception.UserException;
+import com.ktb.joing.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatRoomService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final ChatSocketService chatSocketService;
+
+    // 1대1 채팅방 생성
+    public CreateChatRoomResponse createChatRoom(String username, CreateChatRoomRequest request) {
+        Item item = itemRepository.findById(request.itemId())
+                .orElseThrow(() -> new ItemException(ItemErrorCode.ITEM_NOT_FOUND));
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        User otherUser = userRepository.findById(request.receiverId())
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        String otherRole = request.sender().equals("CREATOR") ? "PRODUCT_MANAGER" : "CREATOR";
+
+        //이미 있는 방인지 확인
+        ChatRoom chatRoom = findExistingChatRoom(username, otherUser)
+                .orElseGet(() -> {
+                    ChatRoom createChatRoom = ChatRoom.builder().item(item).build();
+                    createChatRoom.addMember(user, request.sender()); // 유저 객체, 유저 역할
+                    createChatRoom.addMember(otherUser, otherRole);
+                    return chatRoomRepository.save(createChatRoom);
+                });
+
+        return new CreateChatRoomResponse(chatRoom.getId());
+    }
+
+    // 채팅방 나가기
+    public void leave(String username, Long roomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() ->  new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        chatRoom.removeMember(user);
+
+        //나갔다는 메시지 보내기
+        chatSocketService.sendLeave(username, roomId);
+    }
+
+    // 자신의 채팅방 목록 출력
+    public List<ChatRoomDetailResponse> findChatRooms(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        List<ChatRoom> chatRooms = chatRoomRepository.findMine(user.getUsername());
+        return chatRooms.stream()
+                .map(chatRoom -> toChatRoomDetail(chatRoom, user.getUsername()))
+                .toList();
+
+    }
+
+    // 채팅방 상세정보 변환
+    private ChatRoomDetailResponse toChatRoomDetail(ChatRoom chatRoom, String username) {
+        Optional<ChatMessage> recentMessage = chatMessageRepository.findRecentByChatRoomId(chatRoom.getId());
+        String message = recentMessage.map(ChatMessage::getContent).orElse(null);
+        LocalDateTime messageCreateAt = recentMessage.map(ChatMessage::getCreatedDateTime).orElse(null);
+
+        Optional<User> otherUser = chatRoom.findMembers().stream()
+                .filter(user -> !username.equals(user.getUsername()))
+                        .findAny();
+        String receiverName = otherUser.map(User::getNickname)
+                .orElse(null);
+        String receiverProfileImage = otherUser.map(User::getProfileImage)
+                .orElse(null);
+        return new ChatRoomDetailResponse(chatRoom.getId(), receiverName, receiverProfileImage, message, messageCreateAt);
+    }
+
+
+    // 두 사용자 간의 1대1 채팅방이 이미 존재하는지 확인 -> 새로운 채팅방을 만들기 전에 중복을 방지하는 역할을 한다.
+    private Optional<ChatRoom> findExistingChatRoom(String username, User otherUser) {
+        List<ChatRoom> chatRooms = chatRoomRepository.findMine(username);
+        return chatRooms.stream()
+                .filter(chatRoom -> chatRoom.containsUser(otherUser))
+                .findAny();
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/chat/service/ChatSocketService.java
+++ b/src/main/java/com/ktb/joing/domain/chat/service/ChatSocketService.java
@@ -1,0 +1,80 @@
+package com.ktb.joing.domain.chat.service;
+
+import com.ktb.joing.domain.chat.dto.request.ChatMessageSocketRequest;
+import com.ktb.joing.domain.chat.dto.response.ChatMessageSocketResponse;
+import com.ktb.joing.domain.chat.entity.ChatMessage;
+import com.ktb.joing.domain.chat.entity.ChatRoom;
+import com.ktb.joing.domain.chat.entity.MessageType;
+import com.ktb.joing.domain.chat.exception.ChatErrorCode;
+import com.ktb.joing.domain.chat.exception.ChatException;
+import com.ktb.joing.domain.chat.repository.ChatMessageRepository;
+import com.ktb.joing.domain.chat.repository.ChatRoomRepository;
+import com.ktb.joing.domain.user.entity.User;
+import com.ktb.joing.domain.user.exception.UserErrorCode;
+import com.ktb.joing.domain.user.exception.UserException;
+import com.ktb.joing.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static com.ktb.joing.domain.chat.entity.MessageType.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatSocketService {
+    private static final String TOPIC_CHAT_PREFIX = "/subscribe/rooms/";
+    private static final String EMPTY_CONTENT = "";
+
+    private final SimpMessagingTemplate template;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+
+    // 채팅방 입장 시 발생하는 메시지 처리
+    public void sendEnter(String senderUserId, Long roomId){
+        User senderUser = userRepository.findByUsername(senderUserId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        sendAndSave(ENTER, EMPTY_CONTENT, chatRoom, senderUser);
+    }
+
+    // 채팅방 퇴장 시 발생하는 메시지 처리
+    public void sendLeave(String senderUserId, Long roomId){
+        User senderUser = userRepository.findByUsername(senderUserId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        sendAndSave(LEAVE, EMPTY_CONTENT, chatRoom, senderUser);
+    }
+
+    // 채팅 전송시 발생하는 메시지 처리
+    public void sendChat(String senderUserId, Long roomId, ChatMessageSocketRequest request){
+        User senderUser = userRepository.findByUsername(senderUserId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        if(!chatRoom.containsUser(senderUser)){
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
+        }
+        sendAndSave(CHAT, request.content(), chatRoom, senderUser);
+    }
+
+
+    // 모든 타입의 메시지에 대한 공통 처리 로직
+    private void sendAndSave(MessageType messageType, String content, ChatRoom chatRoom, User senderUser) {
+        ChatMessageSocketResponse chat = new ChatMessageSocketResponse(messageType, content, senderUser, LocalDateTime.now());
+
+        // TODO: 수신자에게 sse 알림 보내기 추가
+
+        template.convertAndSend(TOPIC_CHAT_PREFIX + chatRoom.getId(), chat);
+        chatMessageRepository.save(new ChatMessage(chatRoom, messageType, senderUser, content));
+
+    }
+
+}

--- a/src/main/java/com/ktb/joing/domain/chat/service/ChatSocketService.java
+++ b/src/main/java/com/ktb/joing/domain/chat/service/ChatSocketService.java
@@ -9,6 +9,7 @@ import com.ktb.joing.domain.chat.exception.ChatErrorCode;
 import com.ktb.joing.domain.chat.exception.ChatException;
 import com.ktb.joing.domain.chat.repository.ChatMessageRepository;
 import com.ktb.joing.domain.chat.repository.ChatRoomRepository;
+import com.ktb.joing.domain.notification.service.NotificationService;
 import com.ktb.joing.domain.user.entity.User;
 import com.ktb.joing.domain.user.exception.UserErrorCode;
 import com.ktb.joing.domain.user.exception.UserException;
@@ -33,6 +34,7 @@ public class ChatSocketService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     // 채팅방 입장 시 발생하는 메시지 처리
     public void sendEnter(String senderUserId, Long roomId){
@@ -70,11 +72,24 @@ public class ChatSocketService {
     private void sendAndSave(MessageType messageType, String content, ChatRoom chatRoom, User senderUser) {
         ChatMessageSocketResponse chat = new ChatMessageSocketResponse(messageType, content, senderUser, LocalDateTime.now());
 
-        // TODO: 수신자에게 sse 알림 보내기 추가
+        if (messageType == MessageType.CHAT) {
+            sendChatNotification(chatRoom, senderUser);
+        }
 
         template.convertAndSend(TOPIC_CHAT_PREFIX + chatRoom.getId(), chat);
         chatMessageRepository.save(new ChatMessage(chatRoom, messageType, senderUser, content));
+    }
 
+    //수신자에게 sse 알림 보내기
+    private void sendChatNotification(ChatRoom chatRoom, User senderUser) {
+        String notificationContent = String.format("%s님이 메시지를 보냈습니다.", senderUser.getNickname());
+        String relatedUrl = "/chat/rooms/" + chatRoom.getId();
+        User receiver = chatRoom.findMembers().stream()
+                .filter(user -> !user.getUsername().equals(senderUser.getUsername()))
+                .findFirst()
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        notificationService.send(receiver, notificationContent, relatedUrl);
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #JOING-68

<br/>

## 📝 작업 내용

> 1. 1대1 채팅방 생성 구현 (이 과정에서 중복 채팅방 생성이 방지되도록 하였습니다.)
> 2. 1대1 채팅방 나가기 구현
> 3. 자신이 참여한 모든 1:1 채팅방을 조회
> 4. WebSocket 설정
> 4-1. Interceptor를 추가해 연결 시점(CONNECT)에서 토큰 유효성 검증합니다. 클라이언트에서 온 연결 메시지가 InboundChannel 에 추가되기 전에 JWT 토큰 인증을 수행하고 인증객체를 메세지 헤더에 추가해주는 인증과정을 구현했습니다.
> 4-2. Socket 통신 중 발생하는 에러처리는 기본적으로 구현되어있지만 토큰 인증 문제시 응답을 커스텀하기 위해 StompErrorHandler를 추가했습니다. 토큰 인증 문제시 기존 예외를 재정의하고 응답처리를 부모클래스에게 위임합니다.
> 5. STOMP를 이용한 실시간 채팅 메시지 송수신 구현
> 6. SSE를 이용한 채팅 알림 기능 구현
> 7. 중복 채팅방 생성 방지 로직 구현
>  8. 채팅방 입장/퇴장 시 시스템 메시지 자동 발송


<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 
